### PR TITLE
Task Metadata

### DIFF
--- a/flo-api-generator/src/main/resources/ScalaApi.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApi.mustache
@@ -7,7 +7,7 @@ import com.spotify.flo._
 import scala.reflect.ClassTag
 
 object FloTask {
-  def named[Z: ClassTag](name: String, args: Any*): TaskBuilder0[Z] = new Builder0(name, args:_*)
+  def named[Z: ClassTag](name: String, args: Any*): TaskBuilder0[Z] = Builder0(name, args:_*)
 }
 
 trait TaskBuilder0[Z] {
@@ -21,6 +21,7 @@ trait TaskBuilder0[Z] {
   def ->>(fn: EvalContext => Value[Z]): Task[Z] = processWithContext(fn)
   def └>>(fn: EvalContext => Value[Z]): Task[Z] = processWithContext(fn)
 
+  def meta[ET](key: MetaKey[ET], value: ET): TaskBuilder0[Z]
   def op[A](opProvider: OpProvider[A]): TaskBuilder1[A, Z]
 
   def <[A](task: => Task[A]): TaskBuilder1[A, Z] = in(task)
@@ -45,6 +46,7 @@ trait TaskBuilder{{arity}}[{{typeArgs}}, Z] {
   def └>>(fn: EvalContext => ({{typeArgs}}) => Value[Z]): Task[Z] = processWithContext(fn)
   {{^iter.isLast}}
 
+  def meta[ET](key: MetaKey[ET], value: ET): TaskBuilder{{arity}}[{{typeArgs}}, Z]
   def op[{{nextArg}}](opProvider: OpProvider[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
 
   def in[{{nextArg}}](task: => Task[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]

--- a/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
@@ -9,18 +9,27 @@ import com.spotify.flo.dsl.Util._
 import _root_.scala.collection.JavaConversions
 import _root_.scala.reflect.ClassTag
 
-private[dsl] class Builder0[Z: ClassTag](val name: String, val args: Any*) extends TaskBuilder0[Z] { self =>
+private[dsl] object Builder0 {
+  def apply[Z: ClassTag](name: String, args: Any*): TaskBuilder0[Z] =
+    new Builder0(
+      Task.named(name, args.asInstanceOf[Seq[AnyRef]]:_*)
+        .ofType(implicitly[ClassTag[Z]].runtimeClass.asInstanceOf[Class[Z]]))
 
-  private val cls = implicitly[ClassTag[Z]].runtimeClass.asInstanceOf[Class[Z]]
-  private val builder = Task
-      .named(name, args.asInstanceOf[Seq[AnyRef]]:_*)
-      .ofType(cls)
+  def apply[Z](builder: TaskBuilder[Z]): TaskBuilder0[Z] =
+    new Builder0(builder)
+}
+
+private[dsl] class Builder0[Z](val builder: TaskBuilder[Z]) extends TaskBuilder0[Z] {
+  self =>
 
   override def process(fn: => Z): Task[Z] =
     builder.process(f0(fn))
 
   override def processWithContext(fn: (EvalContext) => Value[Z]): Task[Z] =
     builder.processWithContext(f1(fn))
+
+  override def meta[ET](key: MetaKey[ET], value: ET): TaskBuilder0[Z] =
+    Builder0(self.builder.meta(key, value))
 
   override def op[A1](opProvider: OpProvider[A1]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
     type J1 = A1
@@ -64,6 +73,16 @@ private[dsl] trait Builder{{arity}}[{{typeArgsNumA}}, Z] extends TaskBuilder{{ar
       (ec, {{argumentsNum}}) => fn(ec)({{argumentsPsConv}})
     ))
   {{^iter.isLast}}
+
+  override def meta[ET](key: MetaKey[ET], value: ET): TaskBuilder{{arity}}[{{typeArgsNumA}}, Z] =
+    new Builder{{arity}}[{{typeArgsNumA}}, Z] {
+      type J{{arity}} = self.J{{arity}}
+      val c{{arity}}: J{{arity}} => A{{arity}} = self.c{{arity}}
+      {{^iter.isFirst}}
+      val p: self.p.type = self.p
+      {{/iter.isFirst}}
+      val builder = self.builder.meta(key, value)
+    }
 
   override def op[A{{arityPlus}}](opProvider: OpProvider[A{{arityPlus}}]): TaskBuilder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] =
     new Builder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] {

--- a/flo-api-generator/src/main/resources/TaskBuilder.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilder.mustache
@@ -24,6 +24,7 @@ public interface {{interfaceName}}<Z> {
   Task<Z> process(F0<Z> code);
   Task<Z> processWithContext(F1<EvalContext, EvalContext.Value<Z>> code);
 
+  <ET> {{interfaceName}}<Z> meta(MetaKey<ET> key, ET value);
   <A> {{interfaceName}}1<A, Z> op(OpProvider<A> opProvider);
 
   <A> {{interfaceName}}1<A, Z> in(Fn<Task<A>> task);
@@ -35,6 +36,7 @@ public interface {{interfaceName}}<Z> {
     Task<Z> processWithContext(F{{arityPlus}}<EvalContext, {{typeArgs}}, Value<Z>> code);
   {{^iter.isLast}}
 
+    <ET> {{interfaceName}}{{arity}}<{{typeArgs}}, Z> meta(MetaKey<ET> key, ET value);
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}> opProvider);
 
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> in(Fn<Task<{{nextArg}}>> task);

--- a/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
@@ -1,6 +1,7 @@
 package {{packageName}};
 
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Generated;
 
@@ -44,18 +45,25 @@ final class {{implClassName}} {
 
     @Override
     public Task<Z> process(F0<Z> code) {
-      return Task.create(inputs, ops, type, gated(taskId, code::get), taskId);
+      return Task.create(meta, inputs, ops, type, gated(taskId, code::get), taskId);
     }
 
     @Override
     public Task<Z> processWithContext(F1<EvalContext, Value<Z>> code) {
-      return Task.create(inputs, ops, type, gatedVal(taskId, code::apply), taskId);
+      return Task.create(meta, inputs, ops, type, gatedVal(taskId, code::apply), taskId);
+    }
+
+    @Override
+    public <ET> TaskBuilder<Z> meta(MetaKey<ET> key, ET value) {
+      meta.put(key, value);
+      return this;
     }
 
     @Override
     public <A> TaskBuilder1<A, Z> op(OpProvider<A> opProvider) {
+      opProvider.provideMeta().forEach(entry -> meta.put(entry.key(), entry.value()));
       return new Builder1<>(
-          inputs, appendToList(ops, opProvider), taskId, type,
+          meta, inputs, appendToList(ops, opProvider), taskId, type,
           leafEvalFn(ec -> {
             A aOp = opProvider.provide(ec);
             return ec.immediateValue(f1 -> {
@@ -75,7 +83,7 @@ final class {{implClassName}} {
     public <A> {{interfaceName}}1<A, Z> in(Fn<Task<A>> aTask) {
       Fn<Task<A>> aTaskSingleton = Singleton.create(aTask);
       return new Builder1<>(
-          lazyFlatten(inputs, lazyList(aTaskSingleton)),
+          meta, lazyFlatten(inputs, lazyList(aTaskSingleton)),
           ops, taskId, type,
           leafEvalFn(ec -> {
             Value<A> aValue = ec.evaluate(aTaskSingleton.get());
@@ -87,7 +95,7 @@ final class {{implClassName}} {
     public <A> {{interfaceName}}1<List<A>, Z> ins(Fn<List<Task<A>>> aTasks) {
       Fn<List<Task<A>>> aTasksSingleton = Singleton.create(aTasks);
       return new Builder1<>(
-          lazyFlatten(inputs, lazyFlatten(aTasksSingleton)),
+          meta, lazyFlatten(inputs, lazyFlatten(aTasksSingleton)),
           ops, taskId, type,
           leafEvalFn(ec -> {
             Value<List<A>> aListValue = aTasksSingleton.get()
@@ -106,12 +114,13 @@ final class {{implClassName}} {
     private final ChainingEval<F{{arity}}<{{typeArgs}}, Value<Z>>, Z> evaluator;
 
     Builder{{arity}}(
+        Map<MetaKey<?>, Object> meta,
         Fn<List<Task<?>>> inputs,
         List<OpProvider<?>> ops,
         TaskId taskId,
         Class<Z> type,
         ChainingEval<F{{arity}}<{{typeArgs}}, Value<Z>>, Z> evaluator) {
-      super(inputs, ops, taskId, type);
+      super(meta, inputs, ops, taskId, type);
       this.evaluator = evaluator;
     }
 
@@ -124,7 +133,7 @@ final class {{implClassName}} {
       EvalClosure<Z> closure = ec -> evaluator.enclose(
           ({{arguments}}) -> ec.invokeProcessFn(taskId, () -> ec.value(() -> code.apply({{arguments}})))
       ).eval(ec);
-      return Task.create(inputs, ops, type, closure, taskId);
+      return Task.create(meta, inputs, ops, type, closure, taskId);
     }
 
     @Override
@@ -136,13 +145,20 @@ final class {{implClassName}} {
       EvalClosure<Z> closure = ec -> evaluator.enclose(
           ({{arguments}}) -> ec.invokeProcessFn(taskId, () -> code.apply(ec, {{arguments}}))
       ).eval(ec);
-      return Task.create(inputs, ops, type, closure, taskId);
+      return Task.create(meta, inputs, ops, type, closure, taskId);
+    }
+
+    @Override
+    public <ET> {{interfaceName}}{{arity}}<{{typeArgs}}, Z> meta(MetaKey<ET> key, ET value) {
+      meta.put(key, value);
+      return this;
     }
 
     @Override
     public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}> opProvider) {
+      opProvider.provideMeta().forEach(entry -> meta.put(entry.key(), entry.value()));
       return new Builder{{arityPlus}}<>(
-          inputs, appendToList(ops, opProvider), taskId, type,
+          meta, inputs, appendToList(ops, opProvider), taskId, type,
           evaluator.chain(ec -> {
             {{nextArg}} {{nextArgLow}}Op = opProvider.provide(ec);
             return ec.immediateValue(f{{arityPlus}} -> ({{arguments}}) -> {
@@ -162,7 +178,7 @@ final class {{implClassName}} {
     public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> in(Fn<Task<{{nextArg}}>> nextTask) {
       Fn<Task<{{nextArg}}>> nextTaskSingleton = Singleton.create(nextTask);
       return new Builder{{arityPlus}}<>(
-          lazyFlatten(inputs, lazyList(nextTaskSingleton)),
+          meta, lazyFlatten(inputs, lazyList(nextTaskSingleton)),
           ops, taskId, type,
           evaluator.chain(ec -> {
             Value<{{nextArg}}> nextValue = ec.evaluate(nextTaskSingleton.get());
@@ -174,7 +190,7 @@ final class {{implClassName}} {
     public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, List<{{nextArg}}>, Z> ins(Fn<List<Task<{{nextArg}}>>> nextTasks) {
       Fn<List<Task<{{nextArg}}>>> nextTasksSingleton = Singleton.create(nextTasks);
       return new Builder{{arityPlus}}<>(
-          lazyFlatten(inputs, lazyFlatten(nextTasksSingleton)),
+          meta, lazyFlatten(inputs, lazyFlatten(nextTasksSingleton)),
           ops, taskId, type,
           evaluator.chain(ec -> {
             Value<List<{{nextArg}}>> nextValue = nextTasksSingleton.get()
@@ -190,12 +206,13 @@ final class {{implClassName}} {
     private final ChainingEval<F{{lastArity}}<{{lastTypeArgs}}, Value<Z>>, Z> evaluator;
 
     Builder{{lastArity}}(
+        Map<MetaKey<?>, Object> meta,
         Fn<List<Task<?>>> inputs,
         List<OpProvider<?>> ops,
         TaskId taskId,
         Class<Z> type,
         ChainingEval<F{{lastArity}}<{{lastTypeArgs}}, Value<Z>>, Z> evaluator) {
-      super(inputs, ops, taskId, type);
+      super(meta, inputs, ops, taskId, type);
       this.evaluator = evaluator;
     }
 
@@ -208,7 +225,7 @@ final class {{implClassName}} {
       EvalClosure<Z> closure = ec -> evaluator.enclose(
           ({{lastArguments}}) -> ec.invokeProcessFn(taskId, () -> ec.immediateValue(code.apply({{lastArguments}})))
       ).eval(ec);
-      return Task.create(inputs, ops, type, closure, taskId);
+      return Task.create(meta, inputs, ops, type, closure, taskId);
     }
 
     @Override
@@ -220,7 +237,7 @@ final class {{implClassName}} {
       EvalClosure<Z> closure = ec -> evaluator.enclose(
            ({{lastArguments}}) -> ec.invokeProcessFn(taskId, () -> code.apply(ec, {{lastArguments}}))
       ).eval(ec);
-      return Task.create(inputs, ops, type, closure, taskId);
+      return Task.create(meta, inputs, ops, type, closure, taskId);
     }
   }
 }

--- a/flo-scala/src/test/scala/com/spotify/flo/DslTest.scala
+++ b/flo-scala/src/test/scala/com/spotify/flo/DslTest.scala
@@ -4,6 +4,8 @@ import org.scalatest._
 
 class DslTest extends FlatSpec with Matchers {
 
+  private val metaKey = MetaKey.create[Int]("foo")
+
   "A defTask `$` builder" can "be accessed in dsl scope to create a task" in {
     defTask[String]() dsl ($ -> "hello") shouldBe a [Task[_]]
   }
@@ -28,6 +30,23 @@ class DslTest extends FlatSpec with Matchers {
     def task = defTask(1, 2, 3).process("hello")
 
     task.id.toString shouldBe "task(1,2,3)#2ac733ae"
+  }
+
+  it should "store metadata key-values" in {
+    def task = defTaskNamed("with-meta")
+      .meta(metaKey, 42)
+      .process("hello")
+
+    task.getMeta(metaKey) shouldBe 42
+  }
+
+  it should "store metadata key-values 2" in {
+    def task = defTaskNamed("with-meta")
+      .in(defTaskNamed("inner").process("bla"))
+      .meta(metaKey, 42)
+      .process(_ => "hello")
+
+    task.getMeta(metaKey) shouldBe 42
   }
 
   it must "throw a RuntimeException if accessed outside of defTask" in {

--- a/flo-scala/src/test/scala/com/spotify/flo/Examples.scala
+++ b/flo-scala/src/test/scala/com/spotify/flo/Examples.scala
@@ -33,6 +33,8 @@ object Examples {
     s"world $arg"
   }
 
+  val metaKey: MetaKey[String] = MetaKey.create("meta")
+
   def hello: Task[String] = defTask[String]() dsl (
     $ ┬ world(0)
       ╞ List(world(7), world(14))
@@ -45,6 +47,8 @@ object Examples {
     // upstream dependencies
     in hello
     in world(7)
+
+    meta (metaKey, "meta key value is foo")
 
     // we'll publish this endpoint when the task is done
     op Publisher("MyEndpoint")
@@ -113,7 +117,10 @@ object Publisher {
 
 class Publisher(val endpointId: String) extends OpProvider[Pub] {
   def provide(ec: EvalContext): Pub = new Pub {
-    def pub(uri: String): Unit = println(s"Publishing $uri to $endpointId")
+    def pub(uri: String): Unit = {
+      println(s"Publishing $uri to $endpointId")
+      println(ec.currentTask.get.getMeta(Examples.metaKey))
+    }
   }
 
   override def onSuccess(task: Task[_], z: Any): Unit =

--- a/flo-test/src/main/java/com/spotify/scratch/Scratch.java
+++ b/flo-test/src/main/java/com/spotify/scratch/Scratch.java
@@ -20,7 +20,9 @@
 
 package com.spotify.scratch;
 
+import com.spotify.flo.MetaKey;
 import com.spotify.flo.Task;
+import com.spotify.flo.TaskBuilder;
 import com.spotify.flo.proc.Exec;
 import com.spotify.flo.processor.RootTask;
 
@@ -51,6 +53,9 @@ import com.spotify.flo.processor.RootTask;
  */
 public class Scratch {
 
+  static final MetaKey<String> STRING_VAL = MetaKey.create("String val");
+  static final MetaKey<Integer> INT_VAL = MetaKey.create("Integer val");
+
   public static void main(String[] args) throws Exception {
     Task<Exec.Result> foo = exec("foobar", 123);
     foo.inputsInOrder()
@@ -63,7 +68,9 @@ public class Scratch {
     Task<String> task1 = MyTask.create(parameter);
     Task<Integer> task2 = Adder.create(number, number + 2);
 
-    return Task.named("exec", "/bin/sh").ofType(Exec.Result.class)
+    final TaskBuilder<Exec.Result> exec = Task.named("exec", "/bin/sh").ofType(Exec.Result.class);
+    return exec
+        .meta(STRING_VAL, "hello world")
         .in(() -> task1)
         .in(() -> task2)
         .process(Exec.exec((str, i) -> args("/bin/sh", "-c", "\"echo " + i + "\"")));

--- a/flo-workflow/src/main/java/com/spotify/flo/BaseRefs.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/BaseRefs.java
@@ -21,7 +21,9 @@
 package com.spotify.flo;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A convenience class for holding some reference. This is only so that we don't have to repeat
@@ -30,16 +32,23 @@ import java.util.List;
 class BaseRefs<Z> {
 
   final Fn<List<Task<?>>> inputs;
+  final Map<MetaKey<?>, Object> meta;
   final List<OpProvider<?>> ops;
   final TaskId taskId;
   protected final Class<Z> type;
 
   BaseRefs(TaskId taskId, Class<Z> type) {
-    this(Collections::emptyList, Collections.emptyList(), taskId, type);
+    this(new HashMap<>(), Collections::emptyList, Collections.emptyList(), taskId, type);
   }
 
-  BaseRefs(Fn<List<Task<?>>> inputs, List<OpProvider<?>> ops, TaskId taskId, Class<Z> type) {
+  BaseRefs(
+      Map<MetaKey<?>, Object> meta,
+      Fn<List<Task<?>>> inputs,
+      List<OpProvider<?>> ops,
+      TaskId taskId,
+      Class<Z> type) {
     this.inputs = inputs;
+    this.meta = meta;
     this.ops = ops;
     this.taskId = taskId;
     this.type = type;

--- a/flo-workflow/src/main/java/com/spotify/flo/MetaKey.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/MetaKey.java
@@ -1,0 +1,75 @@
+/*-
+ * -\-\-
+ * Flo Workflow Definition
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo;
+
+/**
+ * A type-safe key for metadata key-value pairs that can be added to a {@link Task}.
+ *
+ * @param <E> The type of the values associated with this key
+ */
+public interface MetaKey<E> {
+
+  String name();
+
+  /**
+   * Should be used to create metadata entries from operators in {@link OpProvider#provideMeta()}.
+   *
+   * @param value The value for the created entry
+   * @return A metadata entry
+   */
+  default Entry<E> value(E value) {
+    return new Entry<E>() {
+      @Override
+      public MetaKey<E> key() {
+        return MetaKey.this;
+      }
+
+      @Override
+      public E value() {
+        return value;
+      }
+    };
+  }
+
+  /**
+   * Create a task metadata key with a given name. Use this static constructor to create key names.
+   *
+   * <p>Keys should ideally be created as static constants.
+   *
+   * <pre>{@code
+   * public static final MetaKey<String> SOME_METADATA = MetaKey.create("Metadata foo");
+   * }</pre>
+   */
+  static <E> MetaKey<E> create(String name) {
+    return () -> name;
+  }
+
+  /**
+   * A type-safe key-value pair for some {@link MetaKey}. These can be created by calling
+   * {@link MetaKey#value(Object)}.
+   *
+   * @param <E> The type of the value
+   */
+  interface Entry<E> {
+    MetaKey<E> key();
+    E value();
+  }
+}

--- a/flo-workflow/src/main/java/com/spotify/flo/OpProvider.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/OpProvider.java
@@ -20,8 +20,11 @@
 
 package com.spotify.flo;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Provider interface for operation objects that will be injected into tasks.
+ * Provider interface for operation objects that will be injected into a {@link Task}.
  *
  * <p>An operator is an object that is aware of the lifecycle of a task and can perform
  * operations before and after the task evaluates. A common use case for operators is to be able
@@ -38,6 +41,10 @@ public interface OpProvider<T> {
    * @return An instance of the provided operator type
    */
   T provide(EvalContext evalContext);
+
+  default List<MetaKey.Entry<?>> provideMeta() {
+    return Collections.emptyList();
+  }
 
   /**
    * Will be called just before a task that is using this operator starts evaluating.

--- a/flo-workflow/src/main/java/com/spotify/flo/Task.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/Task.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -47,12 +48,19 @@ public abstract class Task<T> implements Serializable {
 
   abstract EvalClosure<T> code();
 
+  abstract Map<MetaKey<?>, Object> meta();
+
   abstract Fn<List<Task<?>>> lazyInputs();
 
   public abstract List<OpProvider<?>> ops();
 
   public List<Task<?>> inputs() {
     return lazyInputs().get();
+  }
+
+  public <E> E getMeta(MetaKey<E> key) {
+    //noinspection unchecked
+    return (E) meta().get(key);
   }
 
   public Stream<Task<?>> inputsInOrder() {
@@ -75,19 +83,20 @@ public abstract class Task<T> implements Serializable {
 
   public static <T> Task<T> create(Fn<T> code, Class<T> type, String taskName, Object... args) {
     return create(
-        Collections::emptyList, Collections.emptyList(),
+        Collections.emptyMap(), Collections::emptyList, Collections.emptyList(),
         type,
         ec -> ec.value(code),
         TaskId.create(taskName, args));
   }
 
   static <T> Task<T> create(
+      Map<MetaKey<?>, Object> meta,
       Fn<List<Task<?>>> inputs,
       List<OpProvider<?>> ops,
       Class<T> type,
       EvalClosure<T> code,
       TaskId taskId) {
-    return new AutoValue_Task<>(taskId, type, code, inputs, ops);
+    return new AutoValue_Task<>(taskId, type, code, meta, inputs, ops);
   }
 
   /**


### PR DESCRIPTION
This PR adds support for adding arbitrary, type-safe metadata to tasks. The API is inspired by Kotlins [Coroutine Context Elements](https://github.com/Kotlin/kotlin-coroutines/blob/master/kotlin-coroutines-informal.md#coroutine-context).

Metadata elements are added to tasks keyed on a key type that is parameterized on the value type.

```java
interface MetaKey<E>
```

Metadata key-values can be added to a task through the following builder method.

```java
<E> TaskBuilderX meta(MetaKey<E> key, E value)
```

Added values can be accessed from the `Task` object through a type-safe accessor method.

```java
<E> Optional<E> getMeta(MetaKey<E> key)
```

## Metadata from Operators

Operators can add metadata to a task by supplying a list of entries to the task they are being added to.

```java
List<MetaKey.Entry<?>> provideMeta()
```

In order to make the construction of this list type-safe, `MetaKey<E>` has a method for constructing an `Entry<E>`.

```java
class MyOperator extends OpProvider<String> {

  private static final MetaKey<String> TEST_KEY_1 = MetaKey.create("key1");
  private static final MetaKey<Integer> TEST_KEY_2 = MetaKey.create("key2");

  // ...

  @Override
  public List<MetaKey.Entry<?>> provideMeta() {
    return Arrays.asList(
        TEST_KEY_1.value("foobar"),
        TEST_KEY_2.value(42)
    );
  }
}
```