### PR TITLE
OpProvider interface requires type of Task's evaluated obj

### DIFF
--- a/flo-api-generator/src/main/resources/ScalaApi.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApi.mustache
@@ -21,7 +21,7 @@ trait TaskBuilder0[Z] {
   def ->>(fn: TaskContext => Value[Z]): Task[Z] = processWithContext(fn)
   def └>>(fn: TaskContext => Value[Z]): Task[Z] = processWithContext(fn)
 
-  def op[A](opProvider: OpProvider[A]): TaskBuilder1[A, Z]
+  def op[A](opProvider: OpProvider[A, Z]): TaskBuilder1[A, Z]
 
   def <[A](task: => Task[A]): TaskBuilder1[A, Z] = in(task)
   def <<[A](tasks: => List[Task[A]]): TaskBuilder1[List[A], Z] = ins(tasks)
@@ -45,7 +45,7 @@ trait TaskBuilder{{arity}}[{{typeArgs}}, Z] {
   def └>>(fn: TaskContext => ({{typeArgs}}) => Value[Z]): Task[Z] = processWithContext(fn)
   {{^iter.isLast}}
 
-  def op[{{nextArg}}](opProvider: OpProvider[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
+  def op[{{nextArg}}](opProvider: OpProvider[{{nextArg}}, Z]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
 
   def in[{{nextArg}}](task: => Task[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
   def < [{{nextArg}}](task: => Task[{{nextArg}}]) = in(task)

--- a/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
@@ -23,7 +23,7 @@ private[dsl] class Builder0[Z: ClassTag](val name: String, val args: Any*) exten
   override def processWithContext(fn: (TaskContext) => Value[Z]): Task[Z] =
     builder.processWithContext(f1(fn))
 
-  override def op[A1](opProvider: OpProvider[A1]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
+  override def op[A1](opProvider: OpProvider[A1, Z]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
     type J1 = A1
     val c1: J1 => A1 = identity
     val builder = self.builder.op(opProvider)
@@ -66,7 +66,7 @@ private[dsl] trait Builder{{arity}}[{{typeArgsNumA}}, Z] extends TaskBuilder{{ar
     ))
   {{^iter.isLast}}
 
-  override def op[A{{arityPlus}}](opProvider: OpProvider[A{{arityPlus}}]): TaskBuilder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] =
+  override def op[A{{arityPlus}}](opProvider: OpProvider[A{{arityPlus}}, Z]): TaskBuilder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] =
     new Builder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] {
       type J{{arityPlus}} = A{{arityPlus}}
       val c{{arityPlus}}: J{{arityPlus}} => A{{arityPlus}} = identity

--- a/flo-api-generator/src/main/resources/TaskBuilder.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilder.mustache
@@ -24,7 +24,7 @@ public interface {{interfaceName}}<Z> {
   Task<Z> process(F0<Z> code);
   Task<Z> processWithContext(F1<TaskContext, TaskContext.Value<Z>> code);
 
-  <A> {{interfaceName}}1<A, Z> op(OpProvider<A> opProvider);
+  <A> {{interfaceName}}1<A, Z> op(OpProvider<A, Z> opProvider);
 
   <A> {{interfaceName}}1<A, Z> in(Fn<Task<A>> task);
   <A> {{interfaceName}}1<List<A>, Z> ins(Fn<List<Task<A>>> tasks);
@@ -35,7 +35,7 @@ public interface {{interfaceName}}<Z> {
     Task<Z> processWithContext(F{{arityPlus}}<TaskContext, {{typeArgs}}, Value<Z>> code);
   {{^iter.isLast}}
 
-    <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}> opProvider);
+    <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}, Z> opProvider);
 
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> in(Fn<Task<{{nextArg}}>> task);
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, List<{{nextArg}}>, Z> ins(Fn<List<Task<{{nextArg}}>>> tasks);

--- a/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
@@ -53,7 +53,7 @@ final class {{implClassName}} {
     }
 
     @Override
-    public <A> TaskBuilder1<A, Z> op(OpProvider<A> opProvider) {
+    public <A> TaskBuilder1<A, Z> op(OpProvider<A, Z> opProvider) {
       return new Builder1<>(
           inputs, appendToList(ops, opProvider), taskId, type,
           leafEvalFn(tc -> {
@@ -107,7 +107,7 @@ final class {{implClassName}} {
 
     Builder{{arity}}(
         Fn<List<Task<?>>> inputs,
-        List<OpProvider<?>> ops,
+        List<OpProvider<?, Z>> ops,
         TaskId taskId,
         Class<Z> type,
         ChainingEval<F{{arity}}<{{typeArgs}}, Value<Z>>, Z> evaluator) {
@@ -140,7 +140,7 @@ final class {{implClassName}} {
     }
 
     @Override
-    public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}> opProvider) {
+    public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}, Z> opProvider) {
       return new Builder{{arityPlus}}<>(
           inputs, appendToList(ops, opProvider), taskId, type,
           evaluator.chain(tc -> {
@@ -191,7 +191,7 @@ final class {{implClassName}} {
 
     Builder{{lastArity}}(
         Fn<List<Task<?>>> inputs,
-        List<OpProvider<?>> ops,
+        List<OpProvider<?, Z>> ops,
         TaskId taskId,
         Class<Z> type,
         ChainingEval<F{{lastArity}}<{{lastTypeArgs}}, Value<Z>>, Z> evaluator) {

--- a/flo-scala/src/test/scala/io/rouz/flo/Examples.scala
+++ b/flo-scala/src/test/scala/io/rouz/flo/Examples.scala
@@ -112,11 +112,11 @@ object Publisher {
   def apply(endpointId: String) = new Publisher(endpointId)
 }
 
-class Publisher(val endpointId: String) extends OpProvider[Pub] {
+class Publisher(val endpointId: String) extends OpProvider[Pub, String] {
   def provide(tc: TaskContext): Pub = new Pub {
     def pub(uri: String): Unit = println(s"Publishing $uri to $endpointId")
   }
 
-  override def onSuccess(task: Task[_], z: Any): Unit =
+  override def onSuccess(task: Task[_], z: String): Unit =
     println(s"${task.id} completed with $z")
 }

--- a/workflow/src/main/java/io/rouz/flo/BaseRefs.java
+++ b/workflow/src/main/java/io/rouz/flo/BaseRefs.java
@@ -10,7 +10,7 @@ import java.util.List;
 class BaseRefs<Z> {
 
   final Fn<List<Task<?>>> inputs;
-  final List<OpProvider<?>> ops;
+  final List<OpProvider<?, Z>> ops;
   final TaskId taskId;
   protected final Class<Z> type;
 
@@ -18,7 +18,7 @@ class BaseRefs<Z> {
     this(Collections::emptyList, Collections.emptyList(), taskId, type);
   }
 
-  BaseRefs(Fn<List<Task<?>>> inputs, List<OpProvider<?>> ops, TaskId taskId, Class<Z> type) {
+  BaseRefs(Fn<List<Task<?>>> inputs, List<OpProvider<?, Z>> ops, TaskId taskId, Class<Z> type) {
     this.inputs = inputs;
     this.ops = ops;
     this.taskId = taskId;

--- a/workflow/src/main/java/io/rouz/flo/OpProvider.java
+++ b/workflow/src/main/java/io/rouz/flo/OpProvider.java
@@ -7,7 +7,7 @@ package io.rouz.flo;
  * operations before and after the task evaluates. A common use case for operators is to be able
  * to integrate 3rd party libraries into Flo in a way that makes them easily accessible to tasks.
  */
-public interface OpProvider<T> {
+public interface OpProvider<T, S> {
 
   /**
    * Creates a new operator instance of type {@link T}. The given {@link TaskContext} will be
@@ -33,7 +33,7 @@ public interface OpProvider<T> {
    * @param task The task that evaluated
    * @param z    The return value of the evaluated task
    */
-  default void onSuccess(Task<?> task, Object z) {
+  default void onSuccess(Task<?> task, S z) {
   }
 
   /**

--- a/workflow/src/main/java/io/rouz/flo/Task.java
+++ b/workflow/src/main/java/io/rouz/flo/Task.java
@@ -29,7 +29,7 @@ public abstract class Task<T> implements Serializable {
 
   abstract Fn<List<Task<?>>> lazyInputs();
 
-  public abstract List<OpProvider<?>> ops();
+  public abstract List<OpProvider<?, T>> ops();
 
   public List<Task<?>> inputs() {
     return lazyInputs().get();
@@ -63,7 +63,7 @@ public abstract class Task<T> implements Serializable {
 
   static <T> Task<T> create(
       Fn<List<Task<?>>> inputs,
-      List<OpProvider<?>> ops,
+      List<OpProvider<?, T>> ops,
       Class<T> type,
       EvalClosure<T> code,
       TaskId taskId) {

--- a/workflow/src/test/java/io/rouz/flo/OpProviderTest.java
+++ b/workflow/src/test/java/io/rouz/flo/OpProviderTest.java
@@ -148,7 +148,7 @@ public class OpProviderTest {
     }
   }
 
-  private class TestProvider implements OpProvider<Injected> {
+  private class TestProvider implements OpProvider<Injected, String> {
 
     @Override
     public Injected provide(TaskContext taskContext) {
@@ -156,7 +156,7 @@ public class OpProviderTest {
     }
   }
 
-  private class BasicProvider implements OpProvider<String> {
+  private class BasicProvider implements OpProvider<String, String> {
 
     private final String inject;
 

--- a/workflow/src/test/java/io/rouz/flo/TaskTest.java
+++ b/workflow/src/test/java/io/rouz/flo/TaskTest.java
@@ -31,8 +31,8 @@ public class TaskTest {
 
   @Test
   public void shouldHaveListOfOperators() throws Exception {
-    OpProvider<Object> op1 = tc -> new Object();
-    OpProvider<Object> op2 = tc -> new Object();
+    OpProvider<Object, String> op1 = tc -> new Object();
+    OpProvider<Object, String> op2 = tc -> new Object();
     Task<String> task = Task.named("Inputs").ofType(String.class)
         .op(op1)
         .op(op2)


### PR DESCRIPTION
This will make `onSuccess` safer when the operator expects a well defined type for the returned object from the Task. However, generic operators that would act on `onSuccess` without caring about the returned object are not supported as good anymore. We can have two types of operators, the generic one with a different signature for the `onSuccess` method (i.e. no second argument `z`).