### PR TITLE
[WIP] Add OpProviderStrict

### DIFF
--- a/flo-api-generator/src/main/resources/ScalaApi.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApi.mustache
@@ -22,6 +22,7 @@ trait TaskBuilder0[Z] {
   def └>>(fn: TaskContext => Value[Z]): Task[Z] = processWithContext(fn)
 
   def op[A](opProvider: OpProvider[A]): TaskBuilder1[A, Z]
+  def op[A](opProviderStrict: OpProviderStrict[A, Z]): TaskBuilder1[A, Z]
 
   def <[A](task: => Task[A]): TaskBuilder1[A, Z] = in(task)
   def <<[A](tasks: => List[Task[A]]): TaskBuilder1[List[A], Z] = ins(tasks)
@@ -46,6 +47,7 @@ trait TaskBuilder{{arity}}[{{typeArgs}}, Z] {
   {{^iter.isLast}}
 
   def op[{{nextArg}}](opProvider: OpProvider[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
+  def op[{{nextArg}}](opProviderStrict: OpProviderStrict[{{nextArg}}, Z]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
 
   def in[{{nextArg}}](task: => Task[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
   def < [{{nextArg}}](task: => Task[{{nextArg}}]) = in(task)

--- a/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
@@ -29,6 +29,12 @@ private[dsl] class Builder0[Z: ClassTag](val name: String, val args: Any*) exten
     val builder = self.builder.op(opProvider)
   }
 
+  override def op[A1](opProviderStrict: OpProviderStrict[A1, Z]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
+    type J1 = A1
+    val c1: J1 => A1 = identity
+    val builder = self.builder.op(opProviderStrict)
+  }
+
   override def in[A1](task: => Task[A1]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
     type J1 = A1
     val c1: J1 => A1 = identity
@@ -73,6 +79,14 @@ private[dsl] trait Builder{{arity}}[{{typeArgsNumA}}, Z] extends TaskBuilder{{ar
       val p: self.type = self
       val builder = self.builder.op(opProvider)
     }
+
+  override def op[A{{arityPlus}}](opProviderStrict: OpProviderStrict[A{{arityPlus}}, Z]): TaskBuilder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] =
+    new Builder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] {
+      type J{{arityPlus}} = A{{arityPlus}}
+      val c{{arityPlus}}: J{{arityPlus}} => A{{arityPlus}} = identity
+      val p: self.type = self
+      val builder = self.builder.op(opProviderStrict)
+  }
 
   override def in[A{{arityPlus}}](task: => Task[A{{arityPlus}}]): TaskBuilder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] =
     new Builder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] {

--- a/flo-api-generator/src/main/resources/TaskBuilder.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilder.mustache
@@ -25,6 +25,7 @@ public interface {{interfaceName}}<Z> {
   Task<Z> processWithContext(F1<TaskContext, TaskContext.Value<Z>> code);
 
   <A> {{interfaceName}}1<A, Z> op(OpProvider<A> opProvider);
+  <A> {{interfaceName}}1<A, Z> op(OpProviderStrict<A, Z> opProviderStrict);
 
   <A> {{interfaceName}}1<A, Z> in(Fn<Task<A>> task);
   <A> {{interfaceName}}1<List<A>, Z> ins(Fn<List<Task<A>>> tasks);
@@ -36,6 +37,7 @@ public interface {{interfaceName}}<Z> {
   {{^iter.isLast}}
 
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}> opProvider);
+    <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProviderStrict<{{nextArg}}, Z> opProviderStrict);
 
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> in(Fn<Task<{{nextArg}}>> task);
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, List<{{nextArg}}>, Z> ins(Fn<List<Task<{{nextArg}}>>> tasks);

--- a/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
@@ -44,18 +44,18 @@ final class {{implClassName}} {
 
     @Override
     public Task<Z> process(F0<Z> code) {
-      return Task.create(inputs, ops, type, gated(taskId, code::get), taskId);
+      return Task.create(inputs, ops, strictOps, type, gated(taskId, code::get), taskId);
     }
 
     @Override
     public Task<Z> processWithContext(F1<TaskContext, Value<Z>> code) {
-      return Task.create(inputs, ops, type, gatedVal(taskId, code::apply), taskId);
+      return Task.create(inputs, ops, strictOps, type, gatedVal(taskId, code::apply), taskId);
     }
 
     @Override
     public <A> TaskBuilder1<A, Z> op(OpProvider<A> opProvider) {
       return new Builder1<>(
-          inputs, appendToList(ops, opProvider), taskId, type,
+          inputs, appendToList(ops, opProvider), strictOps, taskId, type,
           leafEvalFn(tc -> {
             A aOp = opProvider.provide(tc);
             return tc.immediateValue(f1 -> {
@@ -63,8 +63,27 @@ final class {{implClassName}} {
               Task<?> task = tc.currentTask().get();
               opProvider.preRun(task);
               Value<Z> zValue = f1.apply(aOp);
-              zValue.consume(z -> opProvider.onSuccess(task, z));
+              zValue.consume(z -> opProvider.onSuccess(task));
               zValue.onFail(throwable -> opProvider.onFail(task, throwable));
+
+              return zValue;
+            });
+          }));
+    }
+
+    @Override
+    public <A> TaskBuilder1<A, Z> op(OpProviderStrict<A, Z> opProviderStrict) {
+      return new Builder1<>(
+          inputs, ops, appendToList(strictOps, opProviderStrict), taskId, type,
+          leafEvalFn(tc -> {
+            A aOp = opProviderStrict.provide(tc);
+            return tc.immediateValue(f1 -> {
+              // call lifecycle methods on op
+              Task<?> task = tc.currentTask().get();
+              opProviderStrict.preRun(task);
+              Value<Z> zValue = f1.apply(aOp);
+              zValue.consume(z -> opProviderStrict.onSuccess(task, z));
+              zValue.onFail(throwable -> opProviderStrict.onFail(task, throwable));
 
               return zValue;
             });
@@ -76,7 +95,7 @@ final class {{implClassName}} {
       Fn<Task<A>> aTaskSingleton = Singleton.create(aTask);
       return new Builder1<>(
           lazyFlatten(inputs, lazyList(aTaskSingleton)),
-          ops, taskId, type,
+          ops, strictOps, taskId, type,
           leafEvalFn(tc -> {
             Value<A> aValue = tc.evaluate(aTaskSingleton.get());
             return aValue.map(a -> f1 -> f1.apply(a));
@@ -88,7 +107,7 @@ final class {{implClassName}} {
       Fn<List<Task<A>>> aTasksSingleton = Singleton.create(aTasks);
       return new Builder1<>(
           lazyFlatten(inputs, lazyFlatten(aTasksSingleton)),
-          ops, taskId, type,
+          ops, strictOps, taskId, type,
           leafEvalFn(tc -> {
             Value<List<A>> aListValue = aTasksSingleton.get()
                 .stream().map(tc::evaluate).collect(toValueList(tc));
@@ -108,10 +127,11 @@ final class {{implClassName}} {
     Builder{{arity}}(
         Fn<List<Task<?>>> inputs,
         List<OpProvider<?>> ops,
+        List<OpProviderStrict<?, Z>> strictOps,
         TaskId taskId,
         Class<Z> type,
         ChainingEval<F{{arity}}<{{typeArgs}}, Value<Z>>, Z> evaluator) {
-      super(inputs, ops, taskId, type);
+      super(inputs, ops, strictOps, taskId, type);
       this.evaluator = evaluator;
     }
 
@@ -124,7 +144,7 @@ final class {{implClassName}} {
       EvalClosure<Z> closure = tc -> evaluator.enclose(
           ({{arguments}}) -> tc.invokeProcessFn(taskId, () -> tc.value(() -> code.apply({{arguments}})))
       ).eval(tc);
-      return Task.create(inputs, ops, type, closure, taskId);
+      return Task.create(inputs, ops, strictOps, type, closure, taskId);
     }
 
     @Override
@@ -136,13 +156,13 @@ final class {{implClassName}} {
       EvalClosure<Z> closure = tc -> evaluator.enclose(
           ({{arguments}}) -> tc.invokeProcessFn(taskId, () -> code.apply(tc, {{arguments}}))
       ).eval(tc);
-      return Task.create(inputs, ops, type, closure, taskId);
+      return Task.create(inputs, ops, strictOps, type, closure, taskId);
     }
 
     @Override
     public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}> opProvider) {
       return new Builder{{arityPlus}}<>(
-          inputs, appendToList(ops, opProvider), taskId, type,
+          inputs, appendToList(ops, opProvider), strictOps, taskId, type,
           evaluator.chain(tc -> {
             {{nextArg}} {{nextArgLow}}Op = opProvider.provide(tc);
             return tc.immediateValue(f{{arityPlus}} -> ({{arguments}}) -> {
@@ -150,8 +170,27 @@ final class {{implClassName}} {
               Task<?> task = tc.currentTask().get();
               opProvider.preRun(task);
               Value<Z> zValue = f{{arityPlus}}.apply({{arguments}}, {{nextArgLow}}Op);
-              zValue.consume(z -> opProvider.onSuccess(task, z));
+              zValue.consume(z -> opProvider.onSuccess(task));
               zValue.onFail(throwable -> opProvider.onFail(task, throwable));
+
+              return zValue;
+            });
+          }));
+    }
+
+    @Override
+    public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProviderStrict<{{nextArg}}, Z> opProviderStrict) {
+      return new Builder{{arityPlus}}<>(
+          inputs, ops, appendToList(strictOps, opProviderStrict), taskId, type,
+          evaluator.chain(tc -> {
+            {{nextArg}} {{nextArgLow}}Op = opProviderStrict.provide(tc);
+            return tc.immediateValue(f{{arityPlus}} -> ({{arguments}}) -> {
+              // call lifecycle methods on op
+              Task<?> task = tc.currentTask().get();
+              opProviderStrict.preRun(task);
+              Value<Z> zValue = f{{arityPlus}}.apply({{arguments}}, {{nextArgLow}}Op);
+              zValue.consume(z -> opProviderStrict.onSuccess(task, z));
+              zValue.onFail(throwable -> opProviderStrict.onFail(task, throwable));
 
               return zValue;
             });
@@ -163,7 +202,7 @@ final class {{implClassName}} {
       Fn<Task<{{nextArg}}>> nextTaskSingleton = Singleton.create(nextTask);
       return new Builder{{arityPlus}}<>(
           lazyFlatten(inputs, lazyList(nextTaskSingleton)),
-          ops, taskId, type,
+          ops, strictOps, taskId, type,
           evaluator.chain(tc -> {
             Value<{{nextArg}}> nextValue = tc.evaluate(nextTaskSingleton.get());
             return nextValue.map(next -> f{{arityPlus}} -> ({{arguments}}) -> f{{arityPlus}}.apply({{arguments}}, next));
@@ -175,7 +214,7 @@ final class {{implClassName}} {
       Fn<List<Task<{{nextArg}}>>> nextTasksSingleton = Singleton.create(nextTasks);
       return new Builder{{arityPlus}}<>(
           lazyFlatten(inputs, lazyFlatten(nextTasksSingleton)),
-          ops, taskId, type,
+          ops, strictOps, taskId, type,
           evaluator.chain(tc -> {
             Value<List<{{nextArg}}>> nextValue = nextTasksSingleton.get()
                 .stream().map(tc::evaluate).collect(toValueList(tc));
@@ -192,10 +231,11 @@ final class {{implClassName}} {
     Builder{{lastArity}}(
         Fn<List<Task<?>>> inputs,
         List<OpProvider<?>> ops,
+        List<OpProviderStrict<?, Z>> strictOps,
         TaskId taskId,
         Class<Z> type,
         ChainingEval<F{{lastArity}}<{{lastTypeArgs}}, Value<Z>>, Z> evaluator) {
-      super(inputs, ops, taskId, type);
+      super(inputs, ops, strictOps, taskId, type);
       this.evaluator = evaluator;
     }
 
@@ -208,7 +248,7 @@ final class {{implClassName}} {
       EvalClosure<Z> closure = tc -> evaluator.enclose(
           ({{lastArguments}}) -> tc.invokeProcessFn(taskId, () -> tc.immediateValue(code.apply({{lastArguments}})))
       ).eval(tc);
-      return Task.create(inputs, ops, type, closure, taskId);
+      return Task.create(inputs, ops, strictOps, type, closure, taskId);
     }
 
     @Override
@@ -220,7 +260,7 @@ final class {{implClassName}} {
       EvalClosure<Z> closure = tc -> evaluator.enclose(
            ({{lastArguments}}) -> tc.invokeProcessFn(taskId, () -> code.apply(tc, {{lastArguments}}))
       ).eval(tc);
-      return Task.create(inputs, ops, type, closure, taskId);
+      return Task.create(inputs, ops, strictOps, type, closure, taskId);
     }
   }
 }

--- a/flo-scala/src/test/scala/com/spotify/flo/Examples.scala
+++ b/flo-scala/src/test/scala/com/spotify/flo/Examples.scala
@@ -111,11 +111,11 @@ object Publisher {
   def apply(endpointId: String) = new Publisher(endpointId)
 }
 
-class Publisher(val endpointId: String) extends OpProvider[Pub] {
+class Publisher(val endpointId: String) extends OpProviderStrict[Pub, String] {
   def provide(tc: TaskContext): Pub = new Pub {
     def pub(uri: String): Unit = println(s"Publishing $uri to $endpointId")
   }
 
-  override def onSuccess(task: Task[_], z: Any): Unit =
-    println(s"${task.id} completed with $z")
+  override def onSuccess(task: Task[_], z: String): Unit =
+    println(s"${task.id} completed with returned string '$z'")
 }

--- a/flo-workflow/src/main/java/com/spotify/flo/BaseRefs.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/BaseRefs.java
@@ -31,16 +31,18 @@ class BaseRefs<Z> {
 
   final Fn<List<Task<?>>> inputs;
   final List<OpProvider<?>> ops;
+  final List<OpProviderStrict<?, Z>> strictOps;
   final TaskId taskId;
   protected final Class<Z> type;
 
   BaseRefs(TaskId taskId, Class<Z> type) {
-    this(Collections::emptyList, Collections.emptyList(), taskId, type);
+    this(Collections::emptyList, Collections.emptyList(), Collections.emptyList(), taskId, type);
   }
 
-  BaseRefs(Fn<List<Task<?>>> inputs, List<OpProvider<?>> ops, TaskId taskId, Class<Z> type) {
+  BaseRefs(Fn<List<Task<?>>> inputs, List<OpProvider<?>> ops, List<OpProviderStrict<?, Z>> strictOps, TaskId taskId, Class<Z> type) {
     this.inputs = inputs;
     this.ops = ops;
+    this.strictOps = strictOps;
     this.taskId = taskId;
     this.type = type;
   }

--- a/flo-workflow/src/main/java/com/spotify/flo/OpProvider.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/OpProvider.java
@@ -51,9 +51,8 @@ public interface OpProvider<T> {
    * Will be called just after a task that is using this operator has successfully evaluated.
    *
    * @param task The task that evaluated
-   * @param z    The return value of the evaluated task
    */
-  default void onSuccess(Task<?> task, Object z) {
+  default void onSuccess(Task<?> task) {
   }
 
   /**

--- a/flo-workflow/src/main/java/com/spotify/flo/OpProviderStrict.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/OpProviderStrict.java
@@ -1,0 +1,54 @@
+/*-
+ * -\-\-
+ * Flo Workflow Definition
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo;
+
+import static java.util.Optional.empty;
+
+import java.util.Optional;
+
+/**
+ * It extends the {@link OpProvider} interface to make the operator aware of the expected return
+ * type of the task. This makes the operator less generic but it allows to override results and
+ * skip the task evaluation as well as utilizing the returned value in case of successful task
+ * execution.
+ */
+public interface OpProviderStrict<T, S> extends OpProvider<T> {
+
+  /**
+   * When a non empty value is returned, the {@link TaskContext} will not evaluate the task or its
+   * upstreams but the returned value is used as task's result.
+   *
+   * @param taskContext The task context in which the current task is being evaluated
+   * @return The optional result to be returned
+   */
+  default Optional<S> overrideResult(TaskContext taskContext) {
+    return empty();
+  }
+
+  /**
+   * Will be called just after a task that is using this operator has successfully evaluated.
+   *
+   * @param task The task that evaluated
+   * @param z    The return value of the evaluated task
+   */
+  default void onSuccess(Task<?> task, S z) {
+  }
+}

--- a/flo-workflow/src/main/java/com/spotify/flo/Task.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/Task.java
@@ -51,6 +51,8 @@ public abstract class Task<T> implements Serializable {
 
   public abstract List<OpProvider<?>> ops();
 
+  public abstract List<OpProviderStrict<?, T>> strictOps();
+
   public List<Task<?>> inputs() {
     return lazyInputs().get();
   }
@@ -75,7 +77,7 @@ public abstract class Task<T> implements Serializable {
 
   public static <T> Task<T> create(Fn<T> code, Class<T> type, String taskName, Object... args) {
     return create(
-        Collections::emptyList, Collections.emptyList(),
+        Collections::emptyList, Collections.emptyList(), Collections.emptyList(),
         type,
         tc -> tc.value(code),
         TaskId.create(taskName, args));
@@ -84,10 +86,11 @@ public abstract class Task<T> implements Serializable {
   static <T> Task<T> create(
       Fn<List<Task<?>>> inputs,
       List<OpProvider<?>> ops,
+      List<OpProviderStrict<?, T>> strictOps,
       Class<T> type,
       EvalClosure<T> code,
       TaskId taskId) {
-    return new AutoValue_Task<>(taskId, type, code, inputs, ops);
+    return new AutoValue_Task<>(taskId, type, code, inputs, ops, strictOps);
   }
 
   /**

--- a/flo-workflow/src/test/java/com/spotify/flo/OpProviderTest.java
+++ b/flo-workflow/src/test/java/com/spotify/flo/OpProviderTest.java
@@ -23,13 +23,18 @@ package com.spotify.flo;
 import static com.spotify.flo.TestUtils.evalAndGet;
 import static com.spotify.flo.TestUtils.evalAndGetException;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.Test;
 import org.mockito.InOrder;
 
@@ -47,6 +52,56 @@ public class OpProviderTest {
 
     assertThat(result, is("ok"));
     assertThat(setFromInjected, is("something foo"));
+  }
+
+  @Test
+  public void shouldOverrideTaskResult() throws Exception {
+    Task<String> task = Task.named("inject").ofType(String.class)
+        .op(new OverridingProvider())
+        .process(injected -> injected.doSomething("foo"));
+
+    String result = evalAndGet(task);
+
+    assertThat(result, is("overridden result"));
+    assertNull(setFromInjected);
+  }
+
+  @Test
+  public void shouldExecuteOnSuccess() throws Exception {
+    StrictBasicProvider strictBasicProvider = spy(new StrictBasicProvider("foo"));
+    Task<String> task = Task.named("inject").ofType(String.class)
+        .op(strictBasicProvider)
+        .process(injected -> {
+          assertThat(injected, is("foo"));
+          return "ok";
+        }
+    );
+
+    String result = evalAndGet(task);
+    assertThat(result, is("ok"));
+    verify(strictBasicProvider).onSuccess(task, "ok");
+  }
+
+  @Test
+  public void shouldOverrideTaskResultWithUpstream() throws Exception {
+    OverridingProvider op1 = spy(new OverridingProvider());
+    TestProvider op2 = spy(new TestProvider());
+    Task<String> task1 = Task.named("inject1").ofType(String.class)
+        .op(op1)
+        .process(injected -> injected.doSomething("foo"));
+
+    Task<String> task2 = Task.named("inject2").ofType(String.class)
+        .op(op2)
+        .in(() -> task1)
+        .process(Injected::doSomething);
+
+    String result = evalAndGet(task2);
+
+    assertThat(result, is("ok"));
+    assertThat(setFromInjected, is("something overridden result"));
+
+    verify(op1, never()).provide(any());
+    verify(op2, times(1)).provide(any());
   }
 
   @Test
@@ -81,8 +136,8 @@ public class OpProviderTest {
     inOrder.verify(op1).preRun(task);
     inOrder.verify(op2).preRun(task);
     inOrder.verify(op1).mark();
-    inOrder.verify(op2).onSuccess(task, "foobar");
-    inOrder.verify(op1).onSuccess(task, "foobar");
+    inOrder.verify(op2).onSuccess(task);
+    inOrder.verify(op1).onSuccess(task);
   }
 
   @Test
@@ -135,7 +190,7 @@ public class OpProviderTest {
     inOrder.verify(t1Fn).get();
     inOrder.verify(op1).preRun(task);
     inOrder.verify(op1).mark();
-    inOrder.verify(op1).onSuccess(task, "hejfoohej");
+    inOrder.verify(op1).onSuccess(task);
   }
 
   @Test
@@ -173,6 +228,37 @@ public class OpProviderTest {
     @Override
     public Injected provide(TaskContext taskContext) {
       return new Injected();
+    }
+  }
+
+  private class OverridingProvider implements OpProviderStrict<Injected, String> {
+
+    @Override
+    public Injected provide(TaskContext taskContext) {
+      return new Injected();
+    }
+
+    @Override
+    public Optional<String> overrideResult(TaskContext taskContext) {
+      return Optional.of("overridden result");
+    }
+  }
+
+  private class StrictBasicProvider implements OpProviderStrict<String, String> {
+
+    private final String inject;
+
+    private StrictBasicProvider(String inject) {
+      this.inject = inject;
+    }
+
+    @Override
+    public String provide(TaskContext taskContext) {
+      return inject;
+    }
+
+    @Override
+    public void onSuccess(Task<?> task, String value) {
     }
   }
 


### PR DESCRIPTION
This makes #29 and #31 obsolete.

Still figuring out how to pass the result value for non-strict OpProvider's `onSuccess` method. Perhaps the best solution is to not give access at all to the result value if the OpProvider is not strict, thus avoiding to operate on generic Object altogether.