### PR TITLE
Add OpProviderStrict and OpProviderGeneric

### DIFF
--- a/flo-api-generator/src/main/resources/ScalaApi.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApi.mustache
@@ -21,7 +21,8 @@ trait TaskBuilder0[Z] {
   def ->>(fn: EvalContext => Value[Z]): Task[Z] = processWithContext(fn)
   def └>>(fn: EvalContext => Value[Z]): Task[Z] = processWithContext(fn)
 
-  def op[A](opProvider: OpProvider[A]): TaskBuilder1[A, Z]
+  def op[A](opProviderGeneric: OpProviderGeneric[A]): TaskBuilder1[A, Z]
+  def op[A](opProviderStrict: OpProviderStrict[A, Z]): TaskBuilder1[A, Z]
 
   def <[A](task: => Task[A]): TaskBuilder1[A, Z] = in(task)
   def <<[A](tasks: => List[Task[A]]): TaskBuilder1[List[A], Z] = ins(tasks)
@@ -45,7 +46,8 @@ trait TaskBuilder{{arity}}[{{typeArgs}}, Z] {
   def └>>(fn: EvalContext => ({{typeArgs}}) => Value[Z]): Task[Z] = processWithContext(fn)
   {{^iter.isLast}}
 
-  def op[{{nextArg}}](opProvider: OpProvider[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
+  def op[{{nextArg}}](opProviderGeneric: OpProviderGeneric[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
+  def op[{{nextArg}}](opProviderStrict: OpProviderStrict[{{nextArg}}, Z]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
 
   def in[{{nextArg}}](task: => Task[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]
   def < [{{nextArg}}](task: => Task[{{nextArg}}]) = in(task)

--- a/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
@@ -22,10 +22,16 @@ private[dsl] class Builder0[Z: ClassTag](val name: String, val args: Any*) exten
   override def processWithContext(fn: (EvalContext) => Value[Z]): Task[Z] =
     builder.processWithContext(f1(fn))
 
-  override def op[A1](opProvider: OpProvider[A1]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
+  override def op[A1](opProviderGeneric: OpProviderGeneric[A1]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
     type J1 = A1
     val c1: J1 => A1 = identity
-    val builder = self.builder.op(opProvider)
+    val builder = self.builder.op(opProviderGeneric)
+  }
+
+  override def op[A1](opProviderStrict: OpProviderStrict[A1, Z]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
+    type J1 = A1
+    val c1: J1 => A1 = identity
+    val builder = self.builder.op(opProviderStrict)
   }
 
   override def in[A1](task: => Task[A1]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
@@ -65,12 +71,20 @@ private[dsl] trait Builder{{arity}}[{{typeArgsNumA}}, Z] extends TaskBuilder{{ar
     ))
   {{^iter.isLast}}
 
-  override def op[A{{arityPlus}}](opProvider: OpProvider[A{{arityPlus}}]): TaskBuilder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] =
+  override def op[A{{arityPlus}}](opProviderGeneric: OpProviderGeneric[A{{arityPlus}}]): TaskBuilder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] =
     new Builder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] {
       type J{{arityPlus}} = A{{arityPlus}}
       val c{{arityPlus}}: J{{arityPlus}} => A{{arityPlus}} = identity
       val p: self.type = self
-      val builder = self.builder.op(opProvider)
+      val builder = self.builder.op(opProviderGeneric)
+    }
+
+  override def op[A{{arityPlus}}](opProviderStrict: OpProviderStrict[A{{arityPlus}}, Z]): TaskBuilder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] =
+    new Builder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] {
+      type J{{arityPlus}} = A{{arityPlus}}
+      val c{{arityPlus}}: J{{arityPlus}} => A{{arityPlus}} = identity
+      val p: self.type = self
+      val builder = self.builder.op(opProviderStrict)
     }
 
   override def in[A{{arityPlus}}](task: => Task[A{{arityPlus}}]): TaskBuilder{{arityPlus}}[{{typeArgsNumA}}, A{{arityPlus}}, Z] =

--- a/flo-api-generator/src/main/resources/TaskBuilder.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilder.mustache
@@ -24,7 +24,8 @@ public interface {{interfaceName}}<Z> {
   Task<Z> process(F0<Z> code);
   Task<Z> processWithContext(F1<EvalContext, EvalContext.Value<Z>> code);
 
-  <A> {{interfaceName}}1<A, Z> op(OpProvider<A> opProvider);
+  <A> {{interfaceName}}1<A, Z> op(OpProviderGeneric<A> opProviderGeneric);
+  <A> {{interfaceName}}1<A, Z> op(OpProviderStrict<A, Z> opProviderStrict);
 
   <A> {{interfaceName}}1<A, Z> in(Fn<Task<A>> task);
   <A> {{interfaceName}}1<List<A>, Z> ins(Fn<List<Task<A>>> tasks);
@@ -35,7 +36,8 @@ public interface {{interfaceName}}<Z> {
     Task<Z> processWithContext(F{{arityPlus}}<EvalContext, {{typeArgs}}, Value<Z>> code);
   {{^iter.isLast}}
 
-    <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}> opProvider);
+    <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProviderGeneric<{{nextArg}}> opProviderGeneric);
+    <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProviderStrict<{{nextArg}}, Z> opProviderStrict);
 
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> in(Fn<Task<{{nextArg}}>> task);
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, List<{{nextArg}}>, Z> ins(Fn<List<Task<{{nextArg}}>>> tasks);

--- a/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
@@ -53,7 +53,16 @@ final class {{implClassName}} {
     }
 
     @Override
-    public <A> TaskBuilder1<A, Z> op(OpProvider<A> opProvider) {
+    public <A> TaskBuilder1<A, Z> op(OpProviderGeneric<A> opProvider) {
+      return op_(opProvider);
+    }
+
+    @Override
+    public <A> TaskBuilder1<A, Z> op(OpProviderStrict<A, Z> opProvider) {
+      return op_(opProvider);
+    }
+
+    private <A> TaskBuilder1<A, Z> op_(OpProvider<A> opProvider) {
       return new Builder1<>(
           inputs, appendToList(ops, opProvider), taskId, type,
           leafEvalFn(ec -> {
@@ -140,7 +149,16 @@ final class {{implClassName}} {
     }
 
     @Override
-    public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProvider<{{nextArg}}> opProvider) {
+    public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProviderGeneric<{{nextArg}}> opProvider) {
+      return op_(opProvider);
+    }
+
+    @Override
+    public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op(OpProviderStrict<{{nextArg}}, Z> opProvider) {
+      return op_(opProvider);
+    }
+
+    private <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> op_(OpProvider<{{nextArg}}> opProvider) {
       return new Builder{{arityPlus}}<>(
           inputs, appendToList(ops, opProvider), taskId, type,
           evaluator.chain(ec -> {

--- a/flo-scala/src/test/scala/com/spotify/flo/Examples.scala
+++ b/flo-scala/src/test/scala/com/spotify/flo/Examples.scala
@@ -108,7 +108,7 @@ object Publisher {
   def apply(endpointId: String) = new Publisher(endpointId)
 }
 
-class Publisher(val endpointId: String) extends OpProvider[Pub] {
+class Publisher(val endpointId: String) extends OpProviderGeneric[Pub] {
   def provide(ec: EvalContext): Pub = new Pub {
     def pub(uri: String): Unit = println(s"Publishing $uri to $endpointId")
   }

--- a/flo-workflow/src/main/java/com/spotify/flo/OpProviderGeneric.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/OpProviderGeneric.java
@@ -1,0 +1,28 @@
+/*-
+ * -\-\-
+ * Flo Workflow Definition
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo;
+
+/**
+ * This is to be extended when building a provider that does not have requirements on the type
+ * of the value returned by the task.
+ */
+public abstract class OpProviderGeneric<T> implements OpProvider<T> {
+}

--- a/flo-workflow/src/main/java/com/spotify/flo/OpProviderStrict.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/OpProviderStrict.java
@@ -1,0 +1,42 @@
+/*-
+ * -\-\-
+ * Flo Workflow Definition
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo;
+
+/**
+ * This is to be extended when building a provider that is intended to work only with a task whose
+ * returned value is of type {@link S}.
+ */
+public abstract class OpProviderStrict<T, S> implements OpProvider<T> {
+
+  @Override
+  final public void onSuccess(Task<?> task, Object z) {
+   onSuccessStrict(task, (S) z);
+  }
+
+  /**
+   * Will be called just after a task that is using this operator has successfully evaluated.
+   *
+   * @param task The task that evaluated
+   * @param z    The return value of the evaluated task
+   */
+  public void onSuccessStrict(Task<?> task, S z) {
+  }
+}

--- a/flo-workflow/src/test/java/com/spotify/flo/TaskTest.java
+++ b/flo-workflow/src/test/java/com/spotify/flo/TaskTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import com.spotify.flo.EvalContext.Promise;
 import java.util.concurrent.atomic.AtomicReference;
@@ -51,8 +52,8 @@ public class TaskTest {
 
   @Test
   public void shouldHaveListOfOperators() throws Exception {
-    OpProvider<Object> op1 = ec -> new Object();
-    OpProvider<Object> op2 = ec -> new Object();
+    final OpProviderGeneric<Object> op1 = mock(OpProviderGeneric.class);
+    final OpProviderGeneric<Object> op2 = mock(OpProviderGeneric.class);
     Task<String> task = Task.named("Inputs").ofType(String.class)
         .op(op1)
         .op(op2)


### PR DESCRIPTION
Makes `OpProvider` a basic interface not to be exposed to providers' implementations. The choice is now between `OpProviderGeneric` (not tied to the task's return type) and `OpProviderStrict` (tied to the task's return type).