### PR TITLE
configure it default to be utf-8 for non-verbose logging

### DIFF
--- a/flo-runner/src/main/resources/logback.xml
+++ b/flo-runner/src/main/resources/logback.xml
@@ -3,6 +3,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
       <name>STDOUT</name>
       <encoder>
+        <charset>UTF-8</charset>
         <pattern>
           %gray(%d{HH:mm:ss.SSS}) %highlight(| %-5level| %-10logger{0}) %green(|>) %msg%n
         </pattern>


### PR DESCRIPTION
@fabriziodemaria PTAL Then we don't need to set `file.encoding`.