### PR TITLE
Run closer of FloRunner thread pool not from inside the thread pool

### DIFF
--- a/flo-runner/src/main/java/com/spotify/flo/context/Logging.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/Logging.java
@@ -51,7 +51,7 @@ public class Logging {
   void willEval(TaskId id) { }
 
   void startEval(TaskId taskId) {
-    LOG.info("{} Running ...", colored(taskId));
+    LOG.info("{} Started", colored(taskId));
   }
 
   <T> void completedValue(TaskId taskId, T value, Duration elapsed) {

--- a/flo-runner/src/test/resources/logback-test.xml
+++ b/flo-runner/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+  <root level="debug">
+    <appender class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <charset>UTF-8</charset>
+        <pattern>%d{HH:mm:ss.SSS} %-5level %logger{0} [%thread] %msg%n</pattern>
+      </encoder>
+    </appender>
+  </root>
+</configuration>


### PR DESCRIPTION
`System.exit` was called on one thread and the logging on another. This made the process exit before any logging had happened.