### PR TITLE
log overridden values similarly to completed values

### DIFF
--- a/flo-runner/src/main/java/com/spotify/flo/context/FloRunner.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/FloRunner.java
@@ -144,7 +144,8 @@ public final class FloRunner<T> {
         MemoizingContext.composeWith(
             OverridingContext.composeWith(
                 LoggingContext.composeWith(
-                    baseContext, logging)));
+                    baseContext, logging),
+                logging));
   }
 
   private EvalContext createRootContext() {

--- a/flo-runner/src/main/java/com/spotify/flo/context/Logging.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/Logging.java
@@ -59,6 +59,14 @@ public class Logging {
         colored(taskId), formatDurationHMS(elapsed.toMillis()), value);
   }
 
+  <T> void overriddenValue(TaskId taskId, T value) {
+    LOG.info("{} has already been computed -> {}", colored(taskId), value);
+  }
+
+  void overriddenValueNotFound(TaskId taskId) {
+    LOG.info("{} has not previously been computed", colored(taskId));
+  }
+
   void failedValue(TaskId taskId, Throwable valueError, Duration elapsed) {
     final String hms = formatDurationHMS(elapsed.toMillis());
     if (valueError instanceof TaskStatusException) {

--- a/flo-runner/src/main/java/com/spotify/flo/context/OverridingContext.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/OverridingContext.java
@@ -35,13 +35,15 @@ import org.slf4j.LoggerFactory;
  */
 public class OverridingContext extends ForwardingEvalContext {
   private static final Logger LOG = LoggerFactory.getLogger(OverridingContext.class);
+  private final Logging logging;
 
-  private OverridingContext(EvalContext delegate) {
+  private OverridingContext(EvalContext delegate, Logging logging) {
     super(delegate);
+    this.logging = logging;
   }
 
-  public static EvalContext composeWith(EvalContext baseContext) {
-    return new OverridingContext(baseContext);
+  public static EvalContext composeWith(EvalContext baseContext, Logging logging) {
+    return new OverridingContext(baseContext, logging);
   }
 
   @Override
@@ -58,9 +60,11 @@ public class OverridingContext extends ForwardingEvalContext {
             if (value.isPresent()) {
               final T t = value.get();
               LOG.debug("Not expanding {}, lookup = {}", colored(task.id()), t);
+              logging.overriddenValue(task.id(), t);
               return context.immediateValue(t);
             } else {
-              LOG.debug("Expanding {}", colored(task.id()));
+              LOG.debug("Lookup not found, expanding {}", colored(task.id()));
+              logging.overriddenValueNotFound(task.id());
               return delegate.evaluateInternal(task, context);
             }
           });


### PR DESCRIPTION
```
> flo-examples/runMain com.spotify.example.ScioStreamCount 2018-03-22T02
[info] Running com.spotify.example.ScioStreamCount 2018-03-22T02
[info] 15:48:19.047 INFO  FloRunner Runner v0.2.2-SNAPSHOT
[info] 15:48:19.051 INFO  FloRunner
[info] 15:48:19.059 INFO  FloRunner Evaluation plan:
[info] 15:48:19.065 INFO  FloRunner streamCount(2018-03-22T02)#0baf2a35
[info] 15:48:19.065 INFO  FloRunner └▸ foobar(2018-03-22T02)#76eb9304
[info] 15:48:19.066 INFO  FloRunner
[info] 15:48:21.008 INFO  FloRunner streamCount(2018-03-22T02)#0baf2a35 has already been computed -> DataEndpoint{id=...}
[info] 15:48:21.018 INFO  FloRunner Total time 00:00:01.678
[success] Total time: 3 s, completed Mar 27, 2018 3:48:21 PM
>
>
>
> flo-examples/runMain com.spotify.example.ScioStreamCount 2018-03-27T15
[info] Running com.spotify.example.ScioStreamCount 2018-03-27T15
[info] 15:48:26.613 INFO  FloRunner Runner v0.2.2-SNAPSHOT
[info] 15:48:26.617 INFO  FloRunner
[info] 15:48:26.626 INFO  FloRunner Evaluation plan:
[info] 15:48:26.633 INFO  FloRunner streamCount(2018-03-27T15)#b00f3dae
[info] 15:48:26.633 INFO  FloRunner └▸ foobar(2018-03-27T15)#76e9e907
[info] 15:48:26.633 INFO  FloRunner
[info] 15:48:28.205 INFO  FloRunner streamCount(2018-03-27T15)#b00f3dae has not previously been computed
[info] 15:48:28.788 INFO  FloRunner foobar(2018-03-27T15)#76e9e907 Started
[info] 15:48:28.953 WARN  FloRunner Could not complete run: NotReady
[info] 15:48:28.959 INFO  FloRunner Total time 00:00:02.112
[info] 15:48:28.960 WARN  FloRunner foobar(2018-03-27T15)#76e9e907 Signalled NotReady after 00:00:00.160
java.lang.RuntimeException: Nonzero exit code returned from runner: 20
        at scala.sys.package$.error(package.scala:27)
[trace] Stack trace suppressed: run last flo-examples/compile:runMain for the full output.
[error] (flo-examples/compile:runMain) Nonzero exit code returned from runner: 20
[error] Total time: 3 s, completed Mar 27, 2018 3:48:29 PM
>
```