### PR TITLE
remove mockito-all dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,11 +146,6 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>
       <scope>test</scope>


### PR DESCRIPTION
This fixes part of the problem with https://github.com/spotify/flo/issues/64

It seems that mockito-all isn't used anywhere? CircleCI tests aren't running automatically, but I ran `mvn verify` locally with my changes and it seems like all tests are passing.