### PR TITLE
downgrade bigquery lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquery</artifactId>
-        <version>1.29.0</version>
+        <version>0.21.0-beta</version>
       </dependency>
 
       <!-- version resolution -->
@@ -164,9 +164,9 @@
         <version>23.0</version>
       </dependency>
       <dependency>
-        <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotations</artifactId>
-        <version>2.2.0</version>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
According to https://github.com/GoogleCloudPlatform/DataflowJavaSDK/issues/607

Later version of `google-cloud-bigquery` depends on `google-api-client-1.23.0` which has compatibility issue with Dataflow.