### PR TITLE
Disable logging downloading progress on mvn verify

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,6 @@ dependencies:
 
 test:
   override:
-    - mvn verify -Pcoverage
+    - mvn verify --batch-mode -Pcoverage
   post:
     - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Disables downloading progress in the `mvn verify -Pcoverage` step, which has a lot of noise in the logs due to artifact download progress that look like: 
```
708/1473 KB   484/6960 KB   472/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   476/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   480/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   484/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   488/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   492/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   496/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   500/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   504/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   508/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   512/2163 KB   247/14092 KB   
708/1473 KB   516/6960 KB   516/2163 KB   247/14092 KB   
708/1473 KB   520/6960 KB   520/2163 KB   247/14092 KB   
708/1473 KB   520/6960 KB   524/2163 KB   247/14092 KB   
708/1473 KB   520/6960 KB   528/2163 KB   247/14092 KB   
708/1473 KB   520/6960 KB   532/2163 KB   247/14092 KB   
708/1473 KB   520/6960 KB   532/2163 KB   247/14092 KB   4/3132 KB   
708/1473 KB   520/6960 KB   532/2163 KB   247/14092 KB   8/3132 KB   
708/1473 KB   520/6960 KB   532/2163 KB   247/14092 KB   12/3132 KB
``` 
and which makes us have to download the logs as a file to be able to fully view them.

Enabling --batch-mode seems to disable the 'interactive' mode which causes those logs, and thus all remaining logs can be fully displayed in circle ci.