### PR TITLE
run task process fn in subprocess

### DIFF
--- a/contrib/flo-styx/pom.xml
+++ b/contrib/flo-styx/pom.xml
@@ -24,12 +24,43 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.norberg</groupId>
+      <artifactId>auto-matter</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!--test deps-->
+    <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.norberg</groupId>
+      <artifactId>auto-matter-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/contrib/flo-styx/pom.xml
+++ b/contrib/flo-styx/pom.xml
@@ -28,10 +28,6 @@
       <artifactId>auto-service</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
     </dependency>

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogMessage.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogMessage.java
@@ -31,6 +31,7 @@ interface StructuredLogMessage {
   @JsonProperty @Nullable String logger();
   @JsonProperty @Nullable String thread();
   @JsonProperty @Nullable String message();
+  @JsonProperty @Nullable String framework();
   @JsonProperty @Nullable String styx_component_id();
   @JsonProperty @Nullable String styx_workflow_id();
   @JsonProperty @Nullable String styx_docker_args();
@@ -40,13 +41,13 @@ interface StructuredLogMessage {
   @JsonProperty @Nullable String styx_execution_id();
   @JsonProperty @Nullable String styx_trigger_id();
   @JsonProperty @Nullable String styx_trigger_type();
-  @JsonProperty @Nullable String flo_task_id();
-  @JsonProperty @Nullable String flo_task_name();
-  @JsonProperty @Nullable String flo_task_args();
+  @JsonProperty @Nullable String task_id();
+  @JsonProperty @Nullable String task_name();
+  @JsonProperty @Nullable String task_args();
 
   StructuredLogMessageBuilder builder();
 
   static StructuredLogMessageBuilder newBuilder() {
-    return new StructuredLogMessageBuilder();
+    return new StructuredLogMessageBuilder().framework("flo");
   }
 }

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogMessage.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogMessage.java
@@ -1,0 +1,52 @@
+/*-
+ * -\-\-
+ * Flo Styx
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.styx;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.norberg.automatter.AutoMatter;
+import javax.annotation.Nullable;
+
+@AutoMatter
+interface StructuredLogMessage {
+  @JsonProperty @Nullable String time();
+  @JsonProperty @Nullable String severity();
+  @JsonProperty @Nullable String logger();
+  @JsonProperty @Nullable String thread();
+  @JsonProperty @Nullable String message();
+  @JsonProperty @Nullable String styx_component_id();
+  @JsonProperty @Nullable String styx_workflow_id();
+  @JsonProperty @Nullable String styx_docker_args();
+  @JsonProperty @Nullable String styx_docker_image();
+  @JsonProperty @Nullable String styx_commit_sha();
+  @JsonProperty @Nullable String styx_parameter();
+  @JsonProperty @Nullable String styx_execution_id();
+  @JsonProperty @Nullable String styx_trigger_id();
+  @JsonProperty @Nullable String styx_trigger_type();
+  @JsonProperty @Nullable String flo_task_id();
+  @JsonProperty @Nullable String flo_task_name();
+  @JsonProperty @Nullable String flo_task_args();
+
+  StructuredLogMessageBuilder builder();
+
+  static StructuredLogMessageBuilder newBuilder() {
+    return new StructuredLogMessageBuilder();
+  }
+}

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogMessage.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogMessage.java
@@ -22,32 +22,56 @@ package com.spotify.flo.contrib.styx;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.norberg.automatter.AutoMatter;
-import javax.annotation.Nullable;
 
 @AutoMatter
 interface StructuredLogMessage {
-  @JsonProperty @Nullable String time();
-  @JsonProperty @Nullable String severity();
-  @JsonProperty @Nullable String logger();
-  @JsonProperty @Nullable String thread();
-  @JsonProperty @Nullable String message();
-  @JsonProperty @Nullable String framework();
-  @JsonProperty @Nullable String styx_component_id();
-  @JsonProperty @Nullable String styx_workflow_id();
-  @JsonProperty @Nullable String styx_docker_args();
-  @JsonProperty @Nullable String styx_docker_image();
-  @JsonProperty @Nullable String styx_commit_sha();
-  @JsonProperty @Nullable String styx_parameter();
-  @JsonProperty @Nullable String styx_execution_id();
-  @JsonProperty @Nullable String styx_trigger_id();
-  @JsonProperty @Nullable String styx_trigger_type();
-  @JsonProperty @Nullable String task_id();
-  @JsonProperty @Nullable String task_name();
-  @JsonProperty @Nullable String task_args();
+  @AutoMatter
+  interface Styx {
+    @JsonProperty String component_id();
+    @JsonProperty String workflow_id();
+    @JsonProperty String docker_args();
+    @JsonProperty String docker_image();
+    @JsonProperty String commit_sha();
+    @JsonProperty String parameter();
+    @JsonProperty String execution_id();
+    @JsonProperty String trigger_id();
+    @JsonProperty String trigger_type();
 
-  StructuredLogMessageBuilder builder();
+    static StyxBuilder newBuilder() {
+      return new StyxBuilder();
+    }
+  }
+
+  @AutoMatter
+  interface Task {
+    @JsonProperty String id();
+    @JsonProperty String name();
+    @JsonProperty String args();
+
+    static TaskBuilder newBuilder() {
+      return new TaskBuilder();
+    }
+  }
+
+  @AutoMatter
+  interface Workflow {
+    @JsonProperty Styx styx();
+    @JsonProperty String framework();
+    @JsonProperty Task task();
+
+    static WorkflowBuilder newBuilder() {
+      return new WorkflowBuilder().framework("flo");
+    }
+  }
+
+  @JsonProperty String time();
+  @JsonProperty String severity();
+  @JsonProperty String logger();
+  @JsonProperty String thread();
+  @JsonProperty String message();
+  @JsonProperty Workflow workflow();
 
   static StructuredLogMessageBuilder newBuilder() {
-    return new StructuredLogMessageBuilder().framework("flo");
+    return new StructuredLogMessageBuilder();
   }
 }

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogging.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogging.java
@@ -1,0 +1,73 @@
+/*-
+ * -\-\-
+ * Flo Styx
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.styx;
+
+import static ch.qos.logback.classic.Level.fromLocationAwareLoggerInteger;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+import java.util.Locale;
+import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+import org.slf4j.event.Level;
+
+public class StructuredLogging {
+
+  private static final String DEFAULT_LOGGING_LEVEL = System.getenv().getOrDefault("FLO_LOGGING_LEVEL", "INFO");
+
+  private StructuredLogging() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static void configureStructuredLogging() {
+    configureStructuredLogging(defaultLoggingLevel());
+  }
+
+  public static void configureStructuredLogging(Level level) {
+    final Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+
+    final LoggerContext context = rootLogger.getLoggerContext();
+    context.reset();
+
+    final StructuredLoggingEncoder encoder = new StructuredLoggingEncoder();
+    encoder.start();
+
+    final ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<ILoggingEvent>();
+    appender.setTarget("System.err");
+    appender.setName("stderr");
+    appender.setEncoder(encoder);
+    appender.setContext(context);
+    appender.start();
+
+    rootLogger.addAppender(appender);
+    rootLogger.setLevel(fromLocationAwareLoggerInteger(level.toInt()));
+
+    rootLogger.info("hello");
+
+    SLF4JBridgeHandler.install();
+  }
+
+  private static Level defaultLoggingLevel() {
+    return Level.valueOf(DEFAULT_LOGGING_LEVEL.toUpperCase(Locale.ROOT));
+  }
+}

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
@@ -105,18 +105,7 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
   }
 
   private TaskId taskId() {
-    final TaskId taskId;
-    if (envTaskId != null) {
-      taskId = envTaskId;
-    } else {
-      final TaskId tracingTaskId = Tracing.TASK_ID.get();
-      if (tracingTaskId != null) {
-        taskId = tracingTaskId;
-      } else {
-        taskId = null;
-      }
-    }
-    return taskId;
+    return envTaskId != null ? envTaskId : Tracing.TASK_ID.get();
   }
 
   private byte[] encodeText(ILoggingEvent event) {

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
@@ -1,0 +1,199 @@
+/*-
+ * -\-\-
+ * Flo Styx
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.styx;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import ch.qos.logback.core.encoder.Encoder;
+import ch.qos.logback.core.encoder.EncoderBase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.spotify.flo.TaskId;
+import com.spotify.flo.Tracing;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Formatter;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A log message {@link Encoder} that emits log messages decorated with Styx and Flo metadata.
+ * If running under Styx, log messages are encoded as Stackdriver structured json and plain
+ * text otherwise for easy reading when developing and running locally.
+ */
+public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectWriter WRITER = MAPPER.writer();
+  private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+  private static final byte[] LINE_SEPARATOR_BYTES = LINE_SEPARATOR.getBytes();
+
+  private final boolean isStyxExecution = System.getenv().containsKey("STYX_EXECUTION_ID");
+  private final StructuredLogMessage template = createTemplate();
+
+  private final TaskId envTaskId;
+
+  public StructuredLoggingEncoder() {
+    this.envTaskId = Optional.ofNullable(System.getenv("FLO_TASK_ID"))
+        .map(TaskId::parse)
+        .orElse(null);
+  }
+
+  @Override
+  public byte[] encode(ILoggingEvent event) {
+    if (isStyxExecution) {
+      return encodeStructured(event);
+    } else {
+      return encodeText(event);
+    }
+  }
+
+  private byte[] encodeStructured(ILoggingEvent event) {
+
+    // Pre-populated with styx metadata
+    final StructuredLogMessageBuilder builder = template.builder();
+
+    // Standard fields
+    builder.time(Instant.ofEpochMilli(event.getTimeStamp()).toString());
+    builder.severity(event.getLevel().toString());
+    builder.logger(event.getLoggerName());
+    builder.thread(event.getThreadName());
+    final StringBuilder message = new StringBuilder(event.getFormattedMessage());
+    final IThrowableProxy t = event.getThrowableProxy();
+    if (t != null) {
+      message.append('\n');
+      writeStack(message, t, "", 0, "\n");
+    }
+    builder.message(message.toString());
+
+    // Flo metadata
+    final TaskId taskId;
+    if (envTaskId != null) {
+      taskId = envTaskId;
+    } else {
+      final TaskId tracingTaskId = Tracing.TASK_ID.get();
+      if (tracingTaskId != null) {
+        taskId = tracingTaskId;
+      } else {
+        taskId = null;
+      }
+    }
+    if (taskId != null) {
+      builder.flo_task_id(taskId.toString());
+      builder.flo_task_name(taskId.name());
+      builder.flo_task_args(taskId.args());
+    }
+
+    // Serialize to json
+    try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      WRITER.writeValue(baos, builder.build());
+      baos.write(LINE_SEPARATOR_BYTES);
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private byte[] encodeText(ILoggingEvent event) {
+    final TaskId taskId = Tracing.TASK_ID.get();
+    final String taskIdString = (taskId != null) ? taskId.toString() : "";
+    final StringBuilder sb = new StringBuilder();
+    final Formatter formatter = new Formatter(sb);
+    formatter.format("%s %-5s [%s] %s: %s%n",
+        Instant.ofEpochMilli(event.getTimeStamp()).toString(),
+        event.getLevel(), taskIdString, loggerName(event), event.getFormattedMessage());
+    final IThrowableProxy t = event.getThrowableProxy();
+    if (t != null) {
+      writeStack(sb, t, "", 0, LINE_SEPARATOR);
+    }
+    return sb.toString().getBytes(UTF_8);
+  }
+
+  private String loggerName(ILoggingEvent event) {
+    final String loggerName = event.getLoggerName();
+    final int ix = loggerName.lastIndexOf('.');
+    if (ix == -1) {
+      return loggerName;
+    } else {
+      return loggerName.substring(ix + 1);
+    }
+  }
+
+  private static void writeStack(StringBuilder sb, IThrowableProxy t, String caption, int indent, String linebreak) {
+    if (t == null) {
+      return;
+    }
+    indent(sb, indent).append(caption).append(t.getClassName()).append(": ").append(t.getMessage()).append(linebreak);
+    final StackTraceElementProxy[] trace = t.getStackTraceElementProxyArray();
+    if (trace != null) {
+      int commonFrames = t.getCommonFrames();
+      int printFrames = trace.length - commonFrames;
+      for (int i = 0; i < printFrames; i++) {
+        indent(sb, indent).append("\t").append(trace[i]).append(linebreak);
+      }
+      if (commonFrames != 0) {
+        indent(sb, indent).append("\t... ").append(commonFrames).append(" more").append(linebreak);
+      }
+      final IThrowableProxy[] suppressed = t.getSuppressed();
+      for (IThrowableProxy st : suppressed) {
+        writeStack(sb, st, "Suppressed: ", indent + 1, linebreak);
+      }
+    }
+
+    writeStack(sb, t.getCause(), "Caused by: ", indent, linebreak);
+  }
+
+  private static StringBuilder indent(StringBuilder sb, int indent) {
+    for (int j = 0; j < indent; ++j) {
+      sb.append('\t');
+    }
+    return sb;
+  }
+
+  @Override
+  public byte[] headerBytes() {
+    return null;
+  }
+
+  @Override
+  public byte[] footerBytes() {
+    return null;
+  }
+
+  private static StructuredLogMessage createTemplate() {
+    final Map<String, String> env = System.getenv();
+    return StructuredLogMessage.newBuilder()
+        .styx_component_id(env.getOrDefault("STYX_COMPONENT_ID", ""))
+        .styx_workflow_id(env.getOrDefault("STYX_WORKFLOW_ID", ""))
+        .styx_docker_args(env.getOrDefault("STYX_DOCKER_ARGS", ""))
+        .styx_docker_image(env.getOrDefault("STYX_DOCKER_IMAGE", ""))
+        .styx_commit_sha(env.getOrDefault("STYX_COMMIT_SHA", ""))
+        .styx_parameter(env.getOrDefault("STYX_PARAMETER", ""))
+        .styx_execution_id(env.getOrDefault("STYX_EXECUTION_ID", ""))
+        .styx_trigger_id(env.getOrDefault("STYX_TRIGGER_ID", ""))
+        .styx_trigger_type(env.getOrDefault("STYX_TRIGGER_TYPE", ""))
+        .build();
+  }
+}

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
@@ -89,22 +89,10 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
     builder.message(message.toString());
 
     // Flo metadata
-    final TaskId taskId;
-    if (envTaskId != null) {
-      taskId = envTaskId;
-    } else {
-      final TaskId tracingTaskId = Tracing.TASK_ID.get();
-      if (tracingTaskId != null) {
-        taskId = tracingTaskId;
-      } else {
-        taskId = null;
-      }
-    }
-    if (taskId != null) {
-      builder.flo_task_id(taskId.toString());
-      builder.flo_task_name(taskId.name());
-      builder.flo_task_args(taskId.args());
-    }
+    final TaskId taskId = taskId();
+    builder.flo_task_id(taskId != null ? taskId.toString() : "");
+    builder.flo_task_name(taskId != null ? taskId.name() : "");
+    builder.flo_task_args(taskId != null ? taskId.args() : "");
 
     // Serialize to json
     try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
@@ -116,8 +104,23 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
     }
   }
 
+  private TaskId taskId() {
+    final TaskId taskId;
+    if (envTaskId != null) {
+      taskId = envTaskId;
+    } else {
+      final TaskId tracingTaskId = Tracing.TASK_ID.get();
+      if (tracingTaskId != null) {
+        taskId = tracingTaskId;
+      } else {
+        taskId = null;
+      }
+    }
+    return taskId;
+  }
+
   private byte[] encodeText(ILoggingEvent event) {
-    final TaskId taskId = Tracing.TASK_ID.get();
+    final TaskId taskId = taskId();
     final String taskIdString = (taskId != null) ? taskId.toString() : "";
     final StringBuilder sb = new StringBuilder();
     final Formatter formatter = new Formatter(sb);

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
@@ -51,7 +51,7 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
   private static final byte[] LINE_SEPARATOR_BYTES = LINE_SEPARATOR.getBytes();
 
   private final boolean isStyxExecution = System.getenv().containsKey("STYX_EXECUTION_ID");
-  private final StructuredLogMessage template = createTemplate();
+  private final StyxBuilder template = createTemplate();
 
   private final TaskId envTaskId;
 
@@ -71,32 +71,36 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
   }
 
   private byte[] encodeStructured(ILoggingEvent event) {
-
-    // Pre-populated with styx metadata
-    final StructuredLogMessageBuilder builder = template.builder();
+    final StructuredLogMessageBuilder structuredLogMessageBuilder =
+        StructuredLogMessage.newBuilder();
 
     // Standard fields
-    builder.time(Instant.ofEpochMilli(event.getTimeStamp()).toString());
-    builder.severity(event.getLevel().toString());
-    builder.logger(event.getLoggerName());
-    builder.thread(event.getThreadName());
+    structuredLogMessageBuilder.time(Instant.ofEpochMilli(event.getTimeStamp()).toString());
+    structuredLogMessageBuilder.severity(event.getLevel().toString());
+    structuredLogMessageBuilder.logger(event.getLoggerName());
+    structuredLogMessageBuilder.thread(event.getThreadName());
     final StringBuilder message = new StringBuilder(event.getFormattedMessage());
     final IThrowableProxy t = event.getThrowableProxy();
     if (t != null) {
       message.append('\n');
       writeStack(message, t, "", 0, "\n");
     }
-    builder.message(message.toString());
+    structuredLogMessageBuilder.message(message.toString());
 
-    // Flo metadata
+    // Workflow metadata
+    final WorkflowBuilder workflowBuilder = StructuredLogMessage.Workflow.newBuilder()
+        .styx(template.build());
     final TaskId taskId = taskId();
-    builder.task_id(taskId != null ? taskId.toString() : "");
-    builder.task_name(taskId != null ? taskId.name() : "");
-    builder.task_args(taskId != null ? taskId.args() : "");
+    workflowBuilder.task(StructuredLogMessage.Task.newBuilder()
+        .id(taskId != null ? taskId.toString() : "")
+        .name(taskId != null ? taskId.name() : "")
+        .args(taskId != null ? taskId.args() : "")
+        .build());
+    structuredLogMessageBuilder.workflow(workflowBuilder.build());
 
     // Serialize to json
     try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-      WRITER.writeValue(baos, builder.build());
+      WRITER.writeValue(baos, structuredLogMessageBuilder.build());
       baos.write(LINE_SEPARATOR_BYTES);
       return baos.toByteArray();
     } catch (IOException e) {
@@ -174,18 +178,17 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
     return null;
   }
 
-  private static StructuredLogMessage createTemplate() {
+  private static StyxBuilder createTemplate() {
     final Map<String, String> env = System.getenv();
-    return StructuredLogMessage.newBuilder()
-        .styx_component_id(env.getOrDefault("STYX_COMPONENT_ID", ""))
-        .styx_workflow_id(env.getOrDefault("STYX_WORKFLOW_ID", ""))
-        .styx_docker_args(env.getOrDefault("STYX_DOCKER_ARGS", ""))
-        .styx_docker_image(env.getOrDefault("STYX_DOCKER_IMAGE", ""))
-        .styx_commit_sha(env.getOrDefault("STYX_COMMIT_SHA", ""))
-        .styx_parameter(env.getOrDefault("STYX_PARAMETER", ""))
-        .styx_execution_id(env.getOrDefault("STYX_EXECUTION_ID", ""))
-        .styx_trigger_id(env.getOrDefault("STYX_TRIGGER_ID", ""))
-        .styx_trigger_type(env.getOrDefault("STYX_TRIGGER_TYPE", ""))
-        .build();
+    return StructuredLogMessage.Styx.newBuilder()
+        .component_id(env.getOrDefault("STYX_COMPONENT_ID", ""))
+        .workflow_id(env.getOrDefault("STYX_WORKFLOW_ID", ""))
+        .docker_args(env.getOrDefault("STYX_DOCKER_ARGS", ""))
+        .docker_image(env.getOrDefault("STYX_DOCKER_IMAGE", ""))
+        .commit_sha(env.getOrDefault("STYX_COMMIT_SHA", ""))
+        .parameter(env.getOrDefault("STYX_PARAMETER", ""))
+        .execution_id(env.getOrDefault("STYX_EXECUTION_ID", ""))
+        .trigger_id(env.getOrDefault("STYX_TRIGGER_ID", ""))
+        .trigger_type(env.getOrDefault("STYX_TRIGGER_TYPE", ""));
   }
 }

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
@@ -90,9 +90,9 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
 
     // Flo metadata
     final TaskId taskId = taskId();
-    builder.flo_task_id(taskId != null ? taskId.toString() : "");
-    builder.flo_task_name(taskId != null ? taskId.name() : "");
-    builder.flo_task_args(taskId != null ? taskId.args() : "");
+    builder.task_id(taskId != null ? taskId.toString() : "");
+    builder.task_name(taskId != null ? taskId.name() : "");
+    builder.task_args(taskId != null ? taskId.args() : "");
 
     // Serialize to json
     try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {

--- a/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
+++ b/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
@@ -1,0 +1,244 @@
+/*-
+ * -\-\-
+ * Flo Styx
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.styx;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.flo.Task;
+import com.spotify.flo.context.FloRunner;
+import io.norberg.automatter.jackson.AutoMatterModule;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+@RunWith(JUnitParamsRunner.class)
+public class StructuredLoggingTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper()
+      .registerModule(new AutoMatterModule());
+
+  @Rule public final SystemErrRule stderr = new SystemErrRule().enableLog();
+  @Rule public final EnvironmentVariables env = new EnvironmentVariables();
+
+  @Before
+  public void setUp() {
+    stderr.clearLog();
+    env.set("FLO_LOGGING_LEVEL", "DEBUG");
+  }
+
+  private void configureLogbackFromFile() {
+    final ch.qos.logback.classic.Logger rootLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(
+        ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+
+    final LoggerContext context = rootLogger.getLoggerContext();
+    context.reset();
+
+    final JoranConfigurator configurator = new JoranConfigurator();
+    configurator.setContext(context);
+    try {
+      configurator.doConfigure(getClass().getResource("/logback.xml"));
+    } catch (JoranException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Parameters({"true", "false"})
+  @Test
+  public void testStructuredLoggingProgrammaticSetup(boolean forking) throws Exception {
+    configureForking(forking);
+    verifyStructuredLogging(() -> StructuredLogging.configureStructuredLogging(Level.DEBUG));
+  }
+
+  @Parameters({"true", "false"})
+  @Test
+  public void testStructuredLoggingFileSetup(boolean forking) throws Exception {
+    configureForking(forking);
+    verifyStructuredLogging(this::configureLogbackFromFile);
+  }
+
+  private void verifyStructuredLogging(Runnable setupLogging) throws Exception {
+    final String styx_component_id = "test_component_id-" + UUID.randomUUID();
+    final String styx_workflow_id = "test_workflow_id-" + UUID.randomUUID();
+    final String styx_docker_args = "test_docker_args-" + UUID.randomUUID();
+    final String styx_docker_image = "test_docker_image-" + UUID.randomUUID();
+    final String styx_commit_sha = "test_commit_sha-" + UUID.randomUUID();
+    final String styx_parameter = "test_parameter-" + UUID.randomUUID();
+    final String styx_execution_id = "test_execution_id-" + UUID.randomUUID();
+    final String styx_trigger_id = "test_trigger_id-" + UUID.randomUUID();
+    final String styx_trigger_type = "test_trigger_type-" + UUID.randomUUID();
+
+    env.set("STYX_COMPONENT_ID", styx_component_id);
+    env.set("STYX_WORKFLOW_ID", styx_workflow_id);
+    env.set("STYX_DOCKER_ARGS", styx_docker_args);
+    env.set("STYX_DOCKER_IMAGE", styx_docker_image);
+    env.set("STYX_COMMIT_SHA", styx_commit_sha);
+    env.set("STYX_PARAMETER", styx_parameter);
+    env.set("STYX_EXECUTION_ID", styx_execution_id);
+    env.set("STYX_TRIGGER_ID", styx_trigger_id);
+    env.set("STYX_TRIGGER_TYPE", styx_trigger_type);
+
+    setupLogging.run();
+
+    final String infoMessageText = "hello world " + UUID.randomUUID();
+    final String errorMessageText = "danger danger! " + UUID.randomUUID();
+
+    final Task<String> task = loggingTask(infoMessageText, errorMessageText);
+
+    final String exceptionStackTrace = FloRunner.runTask(task)
+        .future().get(30, TimeUnit.SECONDS);
+
+    // Wait for log messages to flush
+    Thread.sleep(1000);
+
+    final String output = stderr.getLog();
+    final List<StructuredLogMessage> messages = MAPPER.readerFor(StructuredLogMessage.class)
+        .<StructuredLogMessage>readValues(output)
+        .readAll();
+
+    final StructuredLogMessage infoMessage = messages.stream()
+        .filter(m -> infoMessageText.equals(m.message()))
+        .findFirst().orElseThrow(AssertionError::new);
+
+    final String errorMessageWithException = errorMessageText + "\n" + exceptionStackTrace;
+    final StructuredLogMessage errorMessage = messages.stream()
+        .filter(m -> m.message().equals(errorMessageWithException))
+        .findFirst().orElseThrow(AssertionError::new);
+
+    assertThat(infoMessage.severity(), is("INFO"));
+    assertThat(errorMessage.severity(), is("ERROR"));
+
+    for (StructuredLogMessage message : new StructuredLogMessage[]{infoMessage, errorMessage}) {
+      assertThat((double) Instant.parse(message.time()).toEpochMilli(),
+          is(closeTo(Instant.now().toEpochMilli(), 30_000)));
+      assertThat(message.styx_component_id(), is(styx_component_id));
+      assertThat(message.styx_workflow_id(), is(styx_workflow_id));
+      assertThat(message.styx_docker_args(), is(styx_docker_args));
+      assertThat(message.styx_docker_image(), is(styx_docker_image));
+      assertThat(message.styx_commit_sha(), is(styx_commit_sha));
+      assertThat(message.styx_parameter(), is(styx_parameter));
+      assertThat(message.styx_execution_id(), is(styx_execution_id));
+      assertThat(message.styx_trigger_id(), is(styx_trigger_id));
+      assertThat(message.styx_trigger_type(), is(styx_trigger_type));
+      assertThat(message.flo_task_id(), is(task.id().toString()));
+      assertThat(message.flo_task_name(), is(task.id().name()));
+      assertThat(message.flo_task_args(), is(task.id().args()));
+    }
+  }
+
+  @Parameters({"true", "false"})
+  @Test
+  public void testTextLoggingProgrammaticSetup(boolean forking) throws Exception {
+    configureForking(forking);
+    StructuredLogging.configureStructuredLogging();
+    verifyTextLogging();
+  }
+
+  @Parameters({"true", "false"})
+  @Test
+  public void testTextLoggingFileSetup(boolean forking) throws Exception {
+    configureForking(forking);
+    configureLogbackFromFile();
+    verifyTextLogging();
+  }
+
+  private void verifyTextLogging() throws Exception {
+
+    final String infoMessageText = "hello world " + UUID.randomUUID();
+    final String errorMessageText = "danger danger! " + UUID.randomUUID();
+
+    final Task<String> task = loggingTask(infoMessageText, errorMessageText);
+    final String exceptionStackTrace = FloRunner.runTask(task)
+        .future().get(30, TimeUnit.SECONDS);
+
+    // Wait for log messages to flush
+    Thread.sleep(1000);
+
+    final String output = stderr.getLog();
+    final String lineSeparator = System.getProperty("line.separator");
+    final List<String> lines = Arrays.asList(output.split(lineSeparator));
+
+    lines.stream()
+        .filter(s -> s.contains("[" + task.id() + "]"))
+        .filter(s -> s.contains("INFO"))
+        .filter(s -> s.contains(infoMessageText))
+        .findAny().orElseThrow(AssertionError::new);
+
+    lines.stream()
+        .filter(s -> s.contains("[" + task.id() + "]"))
+        .filter(s -> s.contains("ERROR"))
+        .filter(s -> s.contains(errorMessageText))
+        .findAny().orElseThrow(AssertionError::new);
+    assertThat(output, containsString(exceptionStackTrace));
+  }
+
+  private Task<String> loggingTask(String infoMessage, String errorMessage) {
+    return Task.named("test", UUID.randomUUID().toString(), 4711).ofType(String.class)
+        .process(() -> {
+          final Logger logger = LoggerFactory.getLogger(StructuredLoggingTest.class);
+          logger.info(infoMessage);
+          final Exception exception = exception();
+          logger.error(errorMessage, exception);
+          return stackTrace(exception);
+        });
+  }
+
+  private static String stackTrace(Throwable t) {
+    final StringWriter sw = new StringWriter();
+    final PrintWriter pw = new PrintWriter(sw);
+    t.printStackTrace(pw);
+    pw.flush();
+    return sw.toString();
+  }
+
+  private static Exception exception() {
+    final Exception exception = new Exception("foo!", new IOException("bar!"));
+    exception.addSuppressed(new RuntimeException("suppressed1", new IllegalStateException("inner suppressed1")));
+    exception.addSuppressed(new RuntimeException("suppressed2", new IllegalStateException("inner suppressed2")));
+    return exception;
+  }
+
+  private void configureForking(boolean forking) {
+    env.set("FLO_FORKING", Boolean.toString(forking));
+  }
+}

--- a/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
+++ b/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
@@ -182,6 +182,35 @@ public class StructuredLoggingTest {
     verifyTextLogging();
   }
 
+  @Test
+  public void testStructuredLoggingWithNoMetadata() throws IOException {
+    // Trigger structured logging
+    final String executionId = UUID.randomUUID().toString();
+    env.set("STYX_EXECUTION_ID", executionId);
+
+    configureLogbackFromFile();
+    final Logger logger = LoggerFactory.getLogger("test");
+    logger.info("hello world!");
+    final String output = stderr.getLog();
+
+    final StructuredLogMessage message = MAPPER.readValue(output, StructuredLogMessage.class);
+
+    assertThat(message.styx_execution_id(), is(executionId));
+    assertThat(message.message(), is("hello world!"));
+
+    assertThat(message.styx_component_id(), is(""));
+    assertThat(message.styx_workflow_id(), is(""));
+    assertThat(message.styx_docker_args(), is(""));
+    assertThat(message.styx_docker_image(), is(""));
+    assertThat(message.styx_commit_sha(), is(""));
+    assertThat(message.styx_parameter(), is(""));
+    assertThat(message.styx_trigger_id(), is(""));
+    assertThat(message.styx_trigger_type(), is(""));
+    assertThat(message.flo_task_id(), is(""));
+    assertThat(message.flo_task_name(), is(""));
+    assertThat(message.flo_task_args(), is(""));
+  }
+
   private void verifyTextLogging() throws Exception {
 
     final String infoMessageText = "hello world " + UUID.randomUUID();

--- a/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
+++ b/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
@@ -151,6 +151,7 @@ public class StructuredLoggingTest {
     for (StructuredLogMessage message : new StructuredLogMessage[]{infoMessage, errorMessage}) {
       assertThat((double) Instant.parse(message.time()).toEpochMilli(),
           is(closeTo(Instant.now().toEpochMilli(), 30_000)));
+      assertThat(message.framework(), is("flo"));
       assertThat(message.styx_component_id(), is(styx_component_id));
       assertThat(message.styx_workflow_id(), is(styx_workflow_id));
       assertThat(message.styx_docker_args(), is(styx_docker_args));
@@ -160,9 +161,9 @@ public class StructuredLoggingTest {
       assertThat(message.styx_execution_id(), is(styx_execution_id));
       assertThat(message.styx_trigger_id(), is(styx_trigger_id));
       assertThat(message.styx_trigger_type(), is(styx_trigger_type));
-      assertThat(message.flo_task_id(), is(task.id().toString()));
-      assertThat(message.flo_task_name(), is(task.id().name()));
-      assertThat(message.flo_task_args(), is(task.id().args()));
+      assertThat(message.task_id(), is(task.id().toString()));
+      assertThat(message.task_name(), is(task.id().name()));
+      assertThat(message.task_args(), is(task.id().args()));
     }
   }
 
@@ -197,6 +198,7 @@ public class StructuredLoggingTest {
 
     assertThat(message.styx_execution_id(), is(executionId));
     assertThat(message.message(), is("hello world!"));
+    assertThat(message.framework(), is("flo"));
 
     assertThat(message.styx_component_id(), is(""));
     assertThat(message.styx_workflow_id(), is(""));
@@ -206,9 +208,9 @@ public class StructuredLoggingTest {
     assertThat(message.styx_parameter(), is(""));
     assertThat(message.styx_trigger_id(), is(""));
     assertThat(message.styx_trigger_type(), is(""));
-    assertThat(message.flo_task_id(), is(""));
-    assertThat(message.flo_task_name(), is(""));
-    assertThat(message.flo_task_args(), is(""));
+    assertThat(message.task_id(), is(""));
+    assertThat(message.task_name(), is(""));
+    assertThat(message.task_args(), is(""));
   }
 
   private void verifyTextLogging() throws Exception {

--- a/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
+++ b/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
@@ -151,19 +151,19 @@ public class StructuredLoggingTest {
     for (StructuredLogMessage message : new StructuredLogMessage[]{infoMessage, errorMessage}) {
       assertThat((double) Instant.parse(message.time()).toEpochMilli(),
           is(closeTo(Instant.now().toEpochMilli(), 30_000)));
-      assertThat(message.framework(), is("flo"));
-      assertThat(message.styx_component_id(), is(styx_component_id));
-      assertThat(message.styx_workflow_id(), is(styx_workflow_id));
-      assertThat(message.styx_docker_args(), is(styx_docker_args));
-      assertThat(message.styx_docker_image(), is(styx_docker_image));
-      assertThat(message.styx_commit_sha(), is(styx_commit_sha));
-      assertThat(message.styx_parameter(), is(styx_parameter));
-      assertThat(message.styx_execution_id(), is(styx_execution_id));
-      assertThat(message.styx_trigger_id(), is(styx_trigger_id));
-      assertThat(message.styx_trigger_type(), is(styx_trigger_type));
-      assertThat(message.task_id(), is(task.id().toString()));
-      assertThat(message.task_name(), is(task.id().name()));
-      assertThat(message.task_args(), is(task.id().args()));
+      assertThat(message.workflow().framework(), is("flo"));
+      assertThat(message.workflow().styx().component_id(), is(styx_component_id));
+      assertThat(message.workflow().styx().workflow_id(), is(styx_workflow_id));
+      assertThat(message.workflow().styx().docker_args(), is(styx_docker_args));
+      assertThat(message.workflow().styx().docker_image(), is(styx_docker_image));
+      assertThat(message.workflow().styx().commit_sha(), is(styx_commit_sha));
+      assertThat(message.workflow().styx().parameter(), is(styx_parameter));
+      assertThat(message.workflow().styx().execution_id(), is(styx_execution_id));
+      assertThat(message.workflow().styx().trigger_id(), is(styx_trigger_id));
+      assertThat(message.workflow().styx().trigger_type(), is(styx_trigger_type));
+      assertThat(message.workflow().task().id(), is(task.id().toString()));
+      assertThat(message.workflow().task().name(), is(task.id().name()));
+      assertThat(message.workflow().task().args(), is(task.id().args()));
     }
   }
 
@@ -196,21 +196,21 @@ public class StructuredLoggingTest {
 
     final StructuredLogMessage message = MAPPER.readValue(output, StructuredLogMessage.class);
 
-    assertThat(message.styx_execution_id(), is(executionId));
     assertThat(message.message(), is("hello world!"));
-    assertThat(message.framework(), is("flo"));
 
-    assertThat(message.styx_component_id(), is(""));
-    assertThat(message.styx_workflow_id(), is(""));
-    assertThat(message.styx_docker_args(), is(""));
-    assertThat(message.styx_docker_image(), is(""));
-    assertThat(message.styx_commit_sha(), is(""));
-    assertThat(message.styx_parameter(), is(""));
-    assertThat(message.styx_trigger_id(), is(""));
-    assertThat(message.styx_trigger_type(), is(""));
-    assertThat(message.task_id(), is(""));
-    assertThat(message.task_name(), is(""));
-    assertThat(message.task_args(), is(""));
+    assertThat(message.workflow().styx().execution_id(), is(executionId));
+    assertThat(message.workflow().styx().component_id(), is(""));
+    assertThat(message.workflow().styx().workflow_id(), is(""));
+    assertThat(message.workflow().styx().docker_args(), is(""));
+    assertThat(message.workflow().styx().docker_image(), is(""));
+    assertThat(message.workflow().styx().commit_sha(), is(""));
+    assertThat(message.workflow().styx().parameter(), is(""));
+    assertThat(message.workflow().styx().trigger_id(), is(""));
+    assertThat(message.workflow().styx().trigger_type(), is(""));
+    assertThat(message.workflow().framework(), is("flo"));
+    assertThat(message.workflow().task().id(), is(""));
+    assertThat(message.workflow().task().name(), is(""));
+    assertThat(message.workflow().task().args(), is(""));
   }
 
   private void verifyTextLogging() throws Exception {

--- a/contrib/flo-styx/src/test/resources/logback.xml
+++ b/contrib/flo-styx/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder class="com.spotify.flo.contrib.styx.StructuredLoggingEncoder"/>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/flo-freezer/pom.xml
+++ b/flo-freezer/pom.xml
@@ -22,10 +22,5 @@
       <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo-shaded</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/flo-freezer/pom.xml
+++ b/flo-freezer/pom.xml
@@ -22,5 +22,9 @@
       <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo-shaded</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill-java</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/flo-runner/pom.xml
+++ b/flo-runner/pom.xml
@@ -37,10 +37,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <scope>test</scope>

--- a/flo-runner/src/main/java/com/spotify/flo/context/FloRunner.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/FloRunner.java
@@ -158,11 +158,12 @@ public final class FloRunner<T> {
 
     return
         TracingContext.composeWith(
-            MemoizingContext.composeWith(
-                OverridingContext.composeWith(
-                    LoggingContext.composeWith(
-                        baseContext, logging),
-                    logging)));
+            ForkingContext.composeWith(
+                MemoizingContext.composeWith(
+                    OverridingContext.composeWith(
+                        LoggingContext.composeWith(
+                            baseContext, logging),
+                        logging))));
   }
 
   private EvalContext createRootContext() {

--- a/flo-runner/src/main/java/com/spotify/flo/context/ForkingContext.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/ForkingContext.java
@@ -1,0 +1,149 @@
+/*-
+ * -\-\-
+ * Flo Runner
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.context;
+
+import com.spotify.flo.EvalContext;
+import com.spotify.flo.Fn;
+import com.spotify.flo.Task;
+import com.spotify.flo.TaskId;
+import com.spotify.flo.Tracing;
+import io.grpc.Context;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link EvalContext} that runs tasks in sub-processes.
+ * <p>
+ * Forking can be disabled using the environment variable {@code FLO_DISABLE_FORKING=true}.
+ * <p>
+ * Forking is disabled by default when running in the debugger, but can be enabled by {@code FLO_FORCE_FORK=true}.
+ * <p>
+ * The basic idea here is to intercept the process fn by overriding {@link EvalContext#invokeProcessFn(TaskId, Fn)},
+ * and executing it in a sub-process JVM. The process fn closure and the result is transported in to and out of the
+ * sub-process using serialization.
+ */
+class ForkingContext implements EvalContext {
+
+  private static final Logger log = LoggerFactory.getLogger(ForkingContext.class);
+
+  // This is marked transient so as to avoid serializing the whole stack of EvalContexts
+  private transient final EvalContext delegate;
+
+  private ForkingContext(EvalContext delegate) {
+    this.delegate = Objects.requireNonNull(delegate);
+  }
+
+  static EvalContext composeWith(EvalContext baseContext) {
+    // Is the Java Debug Wire Protocol activated?
+    final boolean inDebugger = ManagementFactory.getRuntimeMXBean().
+        getInputArguments().stream().anyMatch(s -> s.contains("-agentlib:jdwp"));
+
+    final Optional<Boolean> forking = Optional.ofNullable(System.getenv("FLO_FORKING")).map(Boolean::parseBoolean);
+
+    if (forking.isPresent()) {
+      if (forking.get()) {
+        log.debug("Forking enabled (environment variable FLO_FORKING=true)");
+        return new ForkingContext(baseContext);
+      } else {
+        log.debug("Forking disabled (environment variable FLO_FORKING=true)");
+        return baseContext;
+      }
+    } else if (inDebugger) {
+      log.debug("Debugger detected, forking disabled by default "
+          + "(enable by setting environment variable FLO_FORKING=true)");
+      return baseContext;
+    } else {
+      log.debug("Debugger not detected, forking enabled by default "
+          + "(disable by setting environment variable FLO_FORKING=false)");
+      return new ForkingContext(baseContext);
+    }
+  }
+
+  @Override
+  public <T> Value<T> evaluateInternal(Task<T> task, EvalContext context) {
+    return delegate().evaluateInternal(task, context);
+  }
+
+  @Override
+  public <T> Value<T> value(Fn<T> value) {
+    // Note: This method is called from within the process fn lambda, and thus this ForkingContext instance will be
+    // captured in the closure. This method will then be called in the task sub-process. As the delegate field is
+    // transient it will be null and delegate() will return a SyncContext that will immediately call the value fn.
+    return delegate().value(value);
+  }
+
+  @Override
+  public <T> Value<T> immediateValue(T value) {
+    return delegate().immediateValue(value);
+  }
+
+  @Override
+  public <T> Promise<T> promise() {
+    return delegate().promise();
+  }
+
+  @Override
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+    if (delegate == null) {
+      throw new UnsupportedOperationException("nested execution not supported");
+    }
+    // Wrap the process fn in a lambda that will execute the original process fn closure in a sub-process.
+    final Fn<Value<T>> forkingProcessFn = fork(taskId, processFn);
+    // Pass on the wrapped process fn to let the rest of EvalContexts do their thing. The last EvalContext in the chain
+    // will invoke the wrapped lambda, causing the sub-process execution to happen there.
+    return delegate.invokeProcessFn(taskId, forkingProcessFn);
+  }
+
+  private EvalContext delegate() {
+    // The delegate field will be null if this is in the sub-process
+    if (this.delegate == null) {
+      return SyncContext.create();
+    } else {
+      return delegate;
+    }
+  }
+
+  private <T> Fn<Value<T>> fork(TaskId taskId, Fn<Value<T>> value) {
+    return () -> {
+      try (final ForkingExecutor executor = new ForkingExecutor()) {
+        executor.environment(Collections.singletonMap("FLO_TASK_ID", taskId.toString()));
+        return immediateValue(executor.execute(() -> {
+          try {
+            return Context.current()
+                .withValue(Tracing.TASK_ID, taskId)
+                .call(value::get);
+          } catch (RuntimeException e) {
+            throw e;
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        }));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+}

--- a/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
@@ -1,0 +1,378 @@
+/*-
+ * -\-\-
+ * Flo Runner
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.context;
+
+import com.spotify.flo.EvalContext.Value;
+import com.spotify.flo.Fn;
+import com.spotify.flo.freezer.PersistingContext;
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An executor that executes a {@link Fn} in a sub-process JVM.
+ * <p>
+ * The function, its result and any thrown exception must be serializable as
+ * serialization is used to transport these between the processes.
+ */
+class ForkingExecutor implements Closeable {
+
+  private static final Logger log = LoggerFactory.getLogger(ForkingExecutor.class);
+
+  private final List<Execution> executions = new ArrayList<>();
+
+  private Map<String, String> environment = Collections.emptyMap();
+
+  void environment(Map<String, String> environment) {
+    this.environment = Objects.requireNonNull(environment);
+  }
+
+  // TODO: allow just Fn<T>
+
+  /**
+   * Execute a function in a sub-process.
+   *
+   * @param f The function to execute.
+   * @return The return value of the function. Any exception thrown by the
+   *         function the will be propagated and re-thrown.
+   * @throws IOException if
+   */
+  <T> T execute(Fn<Value<T>> f) throws IOException {
+    try (final Execution<T> execution = new Execution<>(f)) {
+      executions.add(execution);
+      execution.start();
+      return execution.waitFor();
+    }
+  }
+
+  @Override
+  public void close() {
+    executions.forEach(Execution::close);
+  }
+
+  private class Execution<T> implements Closeable {
+
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    private final Path tempdir = Files.createTempDirectory("flo-fork");
+
+    private final Path workdir = Files.createDirectory(tempdir.resolve("workdir"));
+
+    private final Path closureFile = tempdir.resolve("closure");
+    private final Path resultFile = tempdir.resolve("result");
+    private final Path errorFile = tempdir.resolve("error");
+
+    private final String home = System.getProperty("java.home");
+    private final String classPath = System.getProperty("java.class.path");
+    private final Path java = Paths.get(home, "bin", "java").toAbsolutePath().normalize();
+
+    private final Fn<Value<T>> f;
+
+    private Process process;
+
+    Execution(Fn<Value<T>> f) throws IOException {
+      this.f = Objects.requireNonNull(f);
+    }
+
+    void start() {
+      if (process != null) {
+        throw new IllegalStateException();
+      }
+      log.debug("serializing closure");
+      try {
+        PersistingContext.serialize(f, closureFile);
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to serialize closure", e);
+      }
+
+      final ProcessBuilder processBuilder = new ProcessBuilder(java.toString(), "-cp", classPath)
+          .directory(workdir.toFile());
+
+      // Propagate -Xmx.
+      // Note: This is suboptimal because if the user has configured a max heap size we will effectively use that
+      // times the concurrent nummber of executing task processes in addition to the heap of the parent process.
+      // However, propagating a lower limit might make the task fail if the user has supplied a heap size that is
+      // tailored to the memory requirements of the task.
+      ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+          .filter(s -> s.startsWith("-Xmx"))
+          .forEach(processBuilder.command()::add);
+
+      // Trampoline arguments
+      processBuilder.command().add(Trampoline.class.getName());
+      processBuilder.command().add(closureFile.toString());
+      processBuilder.command().add(resultFile.toString());
+      processBuilder.command().add(errorFile.toString());
+
+      processBuilder.environment().putAll(environment);
+
+      log.debug("Starting subprocess: environment={}, command={}, directory={}",
+          processBuilder.environment(), processBuilder.command(), processBuilder.directory());
+      try {
+        process = processBuilder.start();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+
+      // Copy std{err,out} line by line to avoid interleaving and corrupting line contents.
+      executor.submit(() -> copyLines(process.getInputStream(), System.out));
+      executor.submit(() -> copyLines(process.getErrorStream(), System.err));
+    }
+
+    T waitFor() {
+      if (process == null) {
+        throw new IllegalStateException();
+      }
+      log.debug("Waiting for subprocess exit");
+      final int exitValue;
+      try {
+        exitValue = process.waitFor();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      } finally {
+        process.destroyForcibly();
+      }
+
+      log.debug("Subprocess exited: " + exitValue);
+      if (exitValue != 0) {
+        throw new RuntimeException("Subprocess failed: " + process.exitValue());
+      }
+
+      if (Files.exists(errorFile)) {
+        // Failed
+        log.debug("Subprocess exited with error file");
+        final Throwable error;
+        try {
+          error = PersistingContext.deserialize(errorFile);
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to deserialize error", e);
+        }
+        if (error instanceof RuntimeException) {
+          throw (RuntimeException) error;
+        } else {
+          throw new RuntimeException(error);
+        }
+      } else {
+        // Success
+        log.debug("Subprocess exited with result file");
+        final T result;
+        try {
+          result = PersistingContext.deserialize(resultFile);
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to deserialize result", e);
+        }
+        return result;
+      }
+    }
+
+    @Override
+    public void close() {
+      if (process != null) {
+        process.destroyForcibly();
+        process = null;
+      }
+      executor.shutdown();
+      tryDeleteDir(tempdir);
+    }
+  }
+
+  private static void tryDeleteDir(Path path) {
+    try {
+      deleteDir(path);
+    } catch (IOException e) {
+      log.warn("Failed to delete directory: {}", path, e);
+    }
+  }
+
+  private static void deleteDir(Path path) throws IOException {
+    try {
+      Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+          try {
+            Files.delete(file);
+          } catch (NoSuchFileException ignore) {
+          }
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+          try {
+            Files.delete(dir);
+          } catch (NoSuchFileException ignore) {
+          }
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    } catch (NoSuchFileException ignore) {
+    }
+  }
+
+  private static void copyLines(InputStream in, PrintStream out) {
+    final BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+    try {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        out.println(line);
+      }
+    } catch (IOException e) {
+      log.error("Caught exception during stream copy", e);
+    }
+  }
+
+  private static class Trampoline {
+
+    private static class Watchdog extends Thread {
+
+      Watchdog() {
+        setDaemon(false);
+      }
+
+      @Override
+      public void run() {
+        // Wait for parent to exit.
+        try {
+          while (true) {
+            int c = System.in.read();
+            if (c == -1) {
+              break;
+            }
+          }
+        } catch (IOException e) {
+          log.error("watchdog failed", e);
+        }
+        log.debug("child process exiting");
+        // Exit with non-zero status code to skip shutdown hooks
+        System.exit(-1);
+      }
+    }
+
+    public static void main(String... args) {
+      log.debug("child process started: args={}", Arrays.asList(args));
+      final Trampoline.Watchdog watchdog = new Trampoline.Watchdog();
+      watchdog.start();
+
+      if (args.length != 3) {
+        log.error("args.length != 3");
+        System.exit(3);
+        return;
+      }
+      final Path closureFile;
+      final Path resultFile;
+      final Path errorFile;
+      try {
+        closureFile = Paths.get(args[0]);
+        resultFile = Paths.get(args[1]);
+        errorFile = Paths.get(args[2]);
+      } catch (InvalidPathException e) {
+        log.error("Failed to get file path", e);
+        System.exit(4);
+        return;
+      }
+
+      run(closureFile, resultFile, errorFile);
+    }
+
+    private static void run(Path closureFile, Path resultFile, Path errorFile) {
+      log.debug("deserializing closure: {}", closureFile);
+      final Fn<Value<?>> fn;
+      try {
+        fn = PersistingContext.deserialize(closureFile);
+      } catch (Exception e) {
+        log.error("Failed to deserialize closure: {}", closureFile, e);
+        System.exit(5);
+        return;
+      }
+
+      log.debug("executing closure");
+      Value<?> value = null;
+      Throwable error = null;
+      try {
+        value = fn.get();
+      } catch (Exception e) {
+        error = e;
+      }
+
+      log.debug("getting result");
+      Object result = null;
+      if (value != null) {
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        value.consume(f::complete);
+        value.onFail(f::completeExceptionally);
+        try {
+          result = f.get();
+        } catch (InterruptedException e) {
+          error = e;
+        } catch (ExecutionException e) {
+          error = e.getCause();
+        }
+      }
+
+      if (error != null) {
+        log.debug("serializing error", error);
+        try {
+          PersistingContext.serialize(error, errorFile);
+        } catch (Exception e) {
+          log.error("failed to serialize error", e);
+          System.exit(6);
+          return;
+        }
+      } else {
+        log.debug("serializing result: {}", result);
+        try {
+          PersistingContext.serialize(result, resultFile);
+        } catch (Exception e) {
+          log.error("failed to serialize result", e);
+          System.exit(7);
+          return;
+        }
+      }
+
+      System.err.flush();
+      System.exit(0);
+    }
+  }
+}

--- a/flo-runner/src/test/java/com/spotify/flo/context/FloRunnerTest.java
+++ b/flo-runner/src/test/java/com/spotify/flo/context/FloRunnerTest.java
@@ -315,12 +315,12 @@ public class FloRunnerTest {
           return bazJvm;
         });
 
-    final Task<String[]> foo = Task.named("foo", baz, yesterday).ofType(String[].class)
+    final Task<String[]> foo = Task.named("foo", yesterday).ofType(String[].class)
         .input(() -> baz)
-        .processWithContext((ctx, bazJvm) -> {
+        .process(bazJvm -> {
           final String fooJvm = jvmName();
-          log.info("foo: ctx={}, fooJvm={}, bazJvm={}, yesterday={}", ctx, fooJvm, bazJvm, yesterday);
-          return ctx.immediateValue(new String[]{bazJvm, fooJvm});
+          log.info("foo: fooJvm={}, bazJvm={}, yesterday={}", fooJvm, bazJvm, yesterday);
+          return new String[]{bazJvm, fooJvm};
         });
 
     final Task<String> quux = Task.named("quux", today).ofType(String.class)

--- a/flo-runner/src/test/java/com/spotify/flo/context/ForkingExecutorTest.java
+++ b/flo-runner/src/test/java/com/spotify/flo/context/ForkingExecutorTest.java
@@ -1,0 +1,88 @@
+/*-
+ * -\-\-
+ * Flo Runner
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.context;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ForkingExecutorTest {
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+  
+  private ForkingExecutor forkingExecutor;
+
+  @Before
+  public void setUp() {
+    forkingExecutor = new ForkingExecutor();
+  }
+
+  @Test
+  public void returnsResult() throws IOException {
+    final String result = forkingExecutor.execute(() ->
+        SyncContext.create().value(() -> "hello world!"));
+    assertThat(result, is("hello world!"));
+  }
+
+  @Test
+  public void propagatesException() throws IOException {
+    exception.expect(FoobarException.class);
+    exception.expectMessage("foobar!");
+    forkingExecutor.execute(() ->
+        SyncContext.create().value(() -> {
+          throw new FoobarException("foobar!");
+        }));
+  }
+
+  @Test
+  public void captures() throws IOException {
+    final Map<String, String> map = new HashMap<>();
+    map.put("foo", "bar");
+    final Map<String, String> result = forkingExecutor.execute(() ->
+        SyncContext.create().value(() -> map));
+    assertThat(result, is(map));
+  }
+
+  @Test
+  public void executesInSubprocess() throws IOException {
+    final String thisJvm = ManagementFactory.getRuntimeMXBean().getName();
+    final String subprocessJvm = forkingExecutor.execute(() ->
+        SyncContext.create().value(() ->
+            ManagementFactory.getRuntimeMXBean().getName()));
+    assertThat(thisJvm, is(not(subprocessJvm)));
+  }
+
+  private static class FoobarException extends RuntimeException {
+
+    FoobarException(String message) {
+      super(message);
+    }
+  }
+}

--- a/flo-runner/src/test/java/com/spotify/flo/context/ForkingExecutorTest.java
+++ b/flo-runner/src/test/java/com/spotify/flo/context/ForkingExecutorTest.java
@@ -36,7 +36,7 @@ import org.junit.rules.ExpectedException;
 public class ForkingExecutorTest {
 
   @Rule public ExpectedException exception = ExpectedException.none();
-  
+
   private ForkingExecutor forkingExecutor;
 
   @Before
@@ -47,7 +47,7 @@ public class ForkingExecutorTest {
   @Test
   public void returnsResult() throws IOException {
     final String result = forkingExecutor.execute(() ->
-        SyncContext.create().value(() -> "hello world!"));
+        "hello world!");
     assertThat(result, is("hello world!"));
   }
 
@@ -55,10 +55,9 @@ public class ForkingExecutorTest {
   public void propagatesException() throws IOException {
     exception.expect(FoobarException.class);
     exception.expectMessage("foobar!");
-    forkingExecutor.execute(() ->
-        SyncContext.create().value(() -> {
-          throw new FoobarException("foobar!");
-        }));
+    forkingExecutor.execute(() -> {
+      throw new FoobarException("foobar!");
+    });
   }
 
   @Test
@@ -66,7 +65,7 @@ public class ForkingExecutorTest {
     final Map<String, String> map = new HashMap<>();
     map.put("foo", "bar");
     final Map<String, String> result = forkingExecutor.execute(() ->
-        SyncContext.create().value(() -> map));
+        map);
     assertThat(result, is(map));
   }
 
@@ -74,8 +73,7 @@ public class ForkingExecutorTest {
   public void executesInSubprocess() throws IOException {
     final String thisJvm = ManagementFactory.getRuntimeMXBean().getName();
     final String subprocessJvm = forkingExecutor.execute(() ->
-        SyncContext.create().value(() ->
-            ManagementFactory.getRuntimeMXBean().getName()));
+        ManagementFactory.getRuntimeMXBean().getName());
     assertThat(thisJvm, is(not(subprocessJvm)));
   }
 

--- a/flo-runner/src/test/resources/logback.xml
+++ b/flo-runner/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDERR" />
+  </root>
+</configuration>

--- a/flo-scala_2.11/pom.xml
+++ b/flo-scala_2.11/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>flo-runner</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.baseVersion}</artifactId>
       <version>3.0.4</version>

--- a/flo-scala_2.12/pom.xml
+++ b/flo-scala_2.12/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>flo-runner</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.baseVersion}</artifactId>
       <version>3.0.4</version>

--- a/flo-scala_2.12/src/test/resources/logback.xml
+++ b/flo-scala_2.12/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDERR" />
+  </root>
+</configuration>

--- a/flo-workflow/pom.xml
+++ b/flo-workflow/pom.xml
@@ -27,10 +27,5 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,27 @@
         <artifactId>grpc-context</artifactId>
         <version>1.4.0</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.9.2</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>1.7.25</version>
+      </dependency>
+      <dependency>
+        <groupId>io.norberg</groupId>
+        <artifactId>auto-matter</artifactId>
+        <version>0.15.0</version>
+        <scope>provided</scope>
+      </dependency>
 
       <!-- test dependencies -->
       <dependency>
@@ -152,6 +173,18 @@
         <version>1.18.0</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>io.norberg</groupId>
+        <artifactId>auto-matter-jackson</artifactId>
+        <version>0.15.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>pl.pragmatists</groupId>
+        <artifactId>JUnitParams</artifactId>
+        <version>1.1.1</version>
+        <scope>test</scope>
+      </dependency>
 
       <!-- dependencies of contrib modules -->
       <dependency>
@@ -170,7 +203,7 @@
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -184,7 +217,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
         <version>4.0.0</version>
       </dependency>
       <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>chill-java</artifactId>
+        <version>0.9.2</version>
+      </dependency>
+      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-context</artifactId>
         <version>1.4.0</version>
@@ -204,6 +209,11 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>2.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -117,12 +117,6 @@
 
       <!-- test dependencies -->
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>1.7.25</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
         <version>0.24</version>
@@ -187,6 +181,12 @@
       <artifactId>auto-value</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
By running the task in a subprocess we can capture all the output on std{out,err} and decorate it with task id etc.

Note: I do worry about the additional overhead in terms of memory usage for each task subprocess. If several tasks run concurrently, we might e.g. hit the memory limit of the container we're running in. The `reference.conf` currently specifies `flo.workers = 4` so we should see up to 5 JVMs running at one time.