### PR TITLE
structured logging for styx

### DIFF
--- a/contrib/flo-styx/pom.xml
+++ b/contrib/flo-styx/pom.xml
@@ -24,12 +24,43 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.norberg</groupId>
+      <artifactId>auto-matter</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!--test deps-->
+    <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.norberg</groupId>
+      <artifactId>auto-matter-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogMessage.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogMessage.java
@@ -1,0 +1,52 @@
+/*-
+ * -\-\-
+ * Flo Styx
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.styx;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.norberg.automatter.AutoMatter;
+import javax.annotation.Nullable;
+
+@AutoMatter
+interface StructuredLogMessage {
+  @JsonProperty @Nullable String time();
+  @JsonProperty @Nullable String severity();
+  @JsonProperty @Nullable String logger();
+  @JsonProperty @Nullable String thread();
+  @JsonProperty @Nullable String message();
+  @JsonProperty @Nullable String styx_component_id();
+  @JsonProperty @Nullable String styx_workflow_id();
+  @JsonProperty @Nullable String styx_docker_args();
+  @JsonProperty @Nullable String styx_docker_image();
+  @JsonProperty @Nullable String styx_commit_sha();
+  @JsonProperty @Nullable String styx_parameter();
+  @JsonProperty @Nullable String styx_execution_id();
+  @JsonProperty @Nullable String styx_trigger_id();
+  @JsonProperty @Nullable String styx_trigger_type();
+  @JsonProperty @Nullable String flo_task_id();
+  @JsonProperty @Nullable String flo_task_name();
+  @JsonProperty @Nullable String flo_task_args();
+
+  StructuredLogMessageBuilder builder();
+
+  static StructuredLogMessageBuilder newBuilder() {
+    return new StructuredLogMessageBuilder();
+  }
+}

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogging.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLogging.java
@@ -1,0 +1,73 @@
+/*-
+ * -\-\-
+ * Flo Styx
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.styx;
+
+import static ch.qos.logback.classic.Level.fromLocationAwareLoggerInteger;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+import java.util.Locale;
+import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+import org.slf4j.event.Level;
+
+public class StructuredLogging {
+
+  private static final String DEFAULT_LOGGING_LEVEL = System.getenv().getOrDefault("FLO_LOGGING_LEVEL", "INFO");
+
+  private StructuredLogging() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static void configureStructuredLogging() {
+    configureStructuredLogging(defaultLoggingLevel());
+  }
+
+  public static void configureStructuredLogging(Level level) {
+    final Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+
+    final LoggerContext context = rootLogger.getLoggerContext();
+    context.reset();
+
+    final StructuredLoggingEncoder encoder = new StructuredLoggingEncoder();
+    encoder.start();
+
+    final ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<ILoggingEvent>();
+    appender.setTarget("System.err");
+    appender.setName("stderr");
+    appender.setEncoder(encoder);
+    appender.setContext(context);
+    appender.start();
+
+    rootLogger.addAppender(appender);
+    rootLogger.setLevel(fromLocationAwareLoggerInteger(level.toInt()));
+
+    rootLogger.info("hello");
+
+    SLF4JBridgeHandler.install();
+  }
+
+  private static Level defaultLoggingLevel() {
+    return Level.valueOf(DEFAULT_LOGGING_LEVEL.toUpperCase(Locale.ROOT));
+  }
+}

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
@@ -105,18 +105,7 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
   }
 
   private TaskId taskId() {
-    final TaskId taskId;
-    if (envTaskId != null) {
-      taskId = envTaskId;
-    } else {
-      final TaskId tracingTaskId = Tracing.TASK_ID.get();
-      if (tracingTaskId != null) {
-        taskId = tracingTaskId;
-      } else {
-        taskId = null;
-      }
-    }
-    return taskId;
+    return envTaskId != null ? envTaskId : Tracing.TASK_ID.get();
   }
 
   private byte[] encodeText(ILoggingEvent event) {

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
@@ -1,0 +1,199 @@
+/*-
+ * -\-\-
+ * Flo Styx
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.styx;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import ch.qos.logback.core.encoder.Encoder;
+import ch.qos.logback.core.encoder.EncoderBase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.spotify.flo.TaskId;
+import com.spotify.flo.Tracing;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Formatter;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A log message {@link Encoder} that emits log messages decorated with Styx and Flo metadata.
+ * If running under Styx, log messages are encoded as Stackdriver structured json and plain
+ * text otherwise for easy reading when developing and running locally.
+ */
+public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectWriter WRITER = MAPPER.writer();
+  private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+  private static final byte[] LINE_SEPARATOR_BYTES = LINE_SEPARATOR.getBytes();
+
+  private final boolean isStyxExecution = System.getenv().containsKey("STYX_EXECUTION_ID");
+  private final StructuredLogMessage template = createTemplate();
+
+  private final TaskId envTaskId;
+
+  public StructuredLoggingEncoder() {
+    this.envTaskId = Optional.ofNullable(System.getenv("FLO_TASK_ID"))
+        .map(TaskId::parse)
+        .orElse(null);
+  }
+
+  @Override
+  public byte[] encode(ILoggingEvent event) {
+    if (isStyxExecution) {
+      return encodeStructured(event);
+    } else {
+      return encodeText(event);
+    }
+  }
+
+  private byte[] encodeStructured(ILoggingEvent event) {
+
+    // Pre-populated with styx metadata
+    final StructuredLogMessageBuilder builder = template.builder();
+
+    // Standard fields
+    builder.time(Instant.ofEpochMilli(event.getTimeStamp()).toString());
+    builder.severity(event.getLevel().toString());
+    builder.logger(event.getLoggerName());
+    builder.thread(event.getThreadName());
+    final StringBuilder message = new StringBuilder(event.getFormattedMessage());
+    final IThrowableProxy t = event.getThrowableProxy();
+    if (t != null) {
+      message.append('\n');
+      writeStack(message, t, "", 0, "\n");
+    }
+    builder.message(message.toString());
+
+    // Flo metadata
+    final TaskId taskId;
+    if (envTaskId != null) {
+      taskId = envTaskId;
+    } else {
+      final TaskId tracingTaskId = Tracing.TASK_ID.get();
+      if (tracingTaskId != null) {
+        taskId = tracingTaskId;
+      } else {
+        taskId = null;
+      }
+    }
+    if (taskId != null) {
+      builder.flo_task_id(taskId.toString());
+      builder.flo_task_name(taskId.name());
+      builder.flo_task_args(taskId.args());
+    }
+
+    // Serialize to json
+    try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      WRITER.writeValue(baos, builder.build());
+      baos.write(LINE_SEPARATOR_BYTES);
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private byte[] encodeText(ILoggingEvent event) {
+    final TaskId taskId = Tracing.TASK_ID.get();
+    final String taskIdString = (taskId != null) ? taskId.toString() : "";
+    final StringBuilder sb = new StringBuilder();
+    final Formatter formatter = new Formatter(sb);
+    formatter.format("%s %-5s [%s] %s: %s%n",
+        Instant.ofEpochMilli(event.getTimeStamp()).toString(),
+        event.getLevel(), taskIdString, loggerName(event), event.getFormattedMessage());
+    final IThrowableProxy t = event.getThrowableProxy();
+    if (t != null) {
+      writeStack(sb, t, "", 0, LINE_SEPARATOR);
+    }
+    return sb.toString().getBytes(UTF_8);
+  }
+
+  private String loggerName(ILoggingEvent event) {
+    final String loggerName = event.getLoggerName();
+    final int ix = loggerName.lastIndexOf('.');
+    if (ix == -1) {
+      return loggerName;
+    } else {
+      return loggerName.substring(ix + 1);
+    }
+  }
+
+  private static void writeStack(StringBuilder sb, IThrowableProxy t, String caption, int indent, String linebreak) {
+    if (t == null) {
+      return;
+    }
+    indent(sb, indent).append(caption).append(t.getClassName()).append(": ").append(t.getMessage()).append(linebreak);
+    final StackTraceElementProxy[] trace = t.getStackTraceElementProxyArray();
+    if (trace != null) {
+      int commonFrames = t.getCommonFrames();
+      int printFrames = trace.length - commonFrames;
+      for (int i = 0; i < printFrames; i++) {
+        indent(sb, indent).append("\t").append(trace[i]).append(linebreak);
+      }
+      if (commonFrames != 0) {
+        indent(sb, indent).append("\t... ").append(commonFrames).append(" more").append(linebreak);
+      }
+      final IThrowableProxy[] suppressed = t.getSuppressed();
+      for (IThrowableProxy st : suppressed) {
+        writeStack(sb, st, "Suppressed: ", indent + 1, linebreak);
+      }
+    }
+
+    writeStack(sb, t.getCause(), "Caused by: ", indent, linebreak);
+  }
+
+  private static StringBuilder indent(StringBuilder sb, int indent) {
+    for (int j = 0; j < indent; ++j) {
+      sb.append('\t');
+    }
+    return sb;
+  }
+
+  @Override
+  public byte[] headerBytes() {
+    return null;
+  }
+
+  @Override
+  public byte[] footerBytes() {
+    return null;
+  }
+
+  private static StructuredLogMessage createTemplate() {
+    final Map<String, String> env = System.getenv();
+    return StructuredLogMessage.newBuilder()
+        .styx_component_id(env.getOrDefault("STYX_COMPONENT_ID", ""))
+        .styx_workflow_id(env.getOrDefault("STYX_WORKFLOW_ID", ""))
+        .styx_docker_args(env.getOrDefault("STYX_DOCKER_ARGS", ""))
+        .styx_docker_image(env.getOrDefault("STYX_DOCKER_IMAGE", ""))
+        .styx_commit_sha(env.getOrDefault("STYX_COMMIT_SHA", ""))
+        .styx_parameter(env.getOrDefault("STYX_PARAMETER", ""))
+        .styx_execution_id(env.getOrDefault("STYX_EXECUTION_ID", ""))
+        .styx_trigger_id(env.getOrDefault("STYX_TRIGGER_ID", ""))
+        .styx_trigger_type(env.getOrDefault("STYX_TRIGGER_TYPE", ""))
+        .build();
+  }
+}

--- a/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
+++ b/contrib/flo-styx/src/main/java/com/spotify/flo/contrib/styx/StructuredLoggingEncoder.java
@@ -89,22 +89,10 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
     builder.message(message.toString());
 
     // Flo metadata
-    final TaskId taskId;
-    if (envTaskId != null) {
-      taskId = envTaskId;
-    } else {
-      final TaskId tracingTaskId = Tracing.TASK_ID.get();
-      if (tracingTaskId != null) {
-        taskId = tracingTaskId;
-      } else {
-        taskId = null;
-      }
-    }
-    if (taskId != null) {
-      builder.flo_task_id(taskId.toString());
-      builder.flo_task_name(taskId.name());
-      builder.flo_task_args(taskId.args());
-    }
+    final TaskId taskId = taskId();
+    builder.flo_task_id(taskId != null ? taskId.toString() : "");
+    builder.flo_task_name(taskId != null ? taskId.name() : "");
+    builder.flo_task_args(taskId != null ? taskId.args() : "");
 
     // Serialize to json
     try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
@@ -116,8 +104,23 @@ public class StructuredLoggingEncoder extends EncoderBase<ILoggingEvent> {
     }
   }
 
+  private TaskId taskId() {
+    final TaskId taskId;
+    if (envTaskId != null) {
+      taskId = envTaskId;
+    } else {
+      final TaskId tracingTaskId = Tracing.TASK_ID.get();
+      if (tracingTaskId != null) {
+        taskId = tracingTaskId;
+      } else {
+        taskId = null;
+      }
+    }
+    return taskId;
+  }
+
   private byte[] encodeText(ILoggingEvent event) {
-    final TaskId taskId = Tracing.TASK_ID.get();
+    final TaskId taskId = taskId();
     final String taskIdString = (taskId != null) ? taskId.toString() : "";
     final StringBuilder sb = new StringBuilder();
     final Formatter formatter = new Formatter(sb);

--- a/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
+++ b/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
@@ -1,0 +1,244 @@
+/*-
+ * -\-\-
+ * Flo Styx
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.styx;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.flo.Task;
+import com.spotify.flo.context.FloRunner;
+import io.norberg.automatter.jackson.AutoMatterModule;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+@RunWith(JUnitParamsRunner.class)
+public class StructuredLoggingTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper()
+      .registerModule(new AutoMatterModule());
+
+  @Rule public final SystemErrRule stderr = new SystemErrRule().enableLog();
+  @Rule public final EnvironmentVariables env = new EnvironmentVariables();
+
+  @Before
+  public void setUp() {
+    stderr.clearLog();
+    env.set("FLO_LOGGING_LEVEL", "DEBUG");
+  }
+
+  private void configureLogbackFromFile() {
+    final ch.qos.logback.classic.Logger rootLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(
+        ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+
+    final LoggerContext context = rootLogger.getLoggerContext();
+    context.reset();
+
+    final JoranConfigurator configurator = new JoranConfigurator();
+    configurator.setContext(context);
+    try {
+      configurator.doConfigure(getClass().getResource("/logback.xml"));
+    } catch (JoranException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Parameters({"true", "false"})
+  @Test
+  public void testStructuredLoggingProgrammaticSetup(boolean forking) throws Exception {
+    configureForking(forking);
+    verifyStructuredLogging(() -> StructuredLogging.configureStructuredLogging(Level.DEBUG));
+  }
+
+  @Parameters({"true", "false"})
+  @Test
+  public void testStructuredLoggingFileSetup(boolean forking) throws Exception {
+    configureForking(forking);
+    verifyStructuredLogging(this::configureLogbackFromFile);
+  }
+
+  private void verifyStructuredLogging(Runnable setupLogging) throws Exception {
+    final String styx_component_id = "test_component_id-" + UUID.randomUUID();
+    final String styx_workflow_id = "test_workflow_id-" + UUID.randomUUID();
+    final String styx_docker_args = "test_docker_args-" + UUID.randomUUID();
+    final String styx_docker_image = "test_docker_image-" + UUID.randomUUID();
+    final String styx_commit_sha = "test_commit_sha-" + UUID.randomUUID();
+    final String styx_parameter = "test_parameter-" + UUID.randomUUID();
+    final String styx_execution_id = "test_execution_id-" + UUID.randomUUID();
+    final String styx_trigger_id = "test_trigger_id-" + UUID.randomUUID();
+    final String styx_trigger_type = "test_trigger_type-" + UUID.randomUUID();
+
+    env.set("STYX_COMPONENT_ID", styx_component_id);
+    env.set("STYX_WORKFLOW_ID", styx_workflow_id);
+    env.set("STYX_DOCKER_ARGS", styx_docker_args);
+    env.set("STYX_DOCKER_IMAGE", styx_docker_image);
+    env.set("STYX_COMMIT_SHA", styx_commit_sha);
+    env.set("STYX_PARAMETER", styx_parameter);
+    env.set("STYX_EXECUTION_ID", styx_execution_id);
+    env.set("STYX_TRIGGER_ID", styx_trigger_id);
+    env.set("STYX_TRIGGER_TYPE", styx_trigger_type);
+
+    setupLogging.run();
+
+    final String infoMessageText = "hello world " + UUID.randomUUID();
+    final String errorMessageText = "danger danger! " + UUID.randomUUID();
+
+    final Task<String> task = loggingTask(infoMessageText, errorMessageText);
+
+    final String exceptionStackTrace = FloRunner.runTask(task)
+        .future().get(30, TimeUnit.SECONDS);
+
+    // Wait for log messages to flush
+    Thread.sleep(1000);
+
+    final String output = stderr.getLog();
+    final List<StructuredLogMessage> messages = MAPPER.readerFor(StructuredLogMessage.class)
+        .<StructuredLogMessage>readValues(output)
+        .readAll();
+
+    final StructuredLogMessage infoMessage = messages.stream()
+        .filter(m -> infoMessageText.equals(m.message()))
+        .findFirst().orElseThrow(AssertionError::new);
+
+    final String errorMessageWithException = errorMessageText + "\n" + exceptionStackTrace;
+    final StructuredLogMessage errorMessage = messages.stream()
+        .filter(m -> m.message().equals(errorMessageWithException))
+        .findFirst().orElseThrow(AssertionError::new);
+
+    assertThat(infoMessage.severity(), is("INFO"));
+    assertThat(errorMessage.severity(), is("ERROR"));
+
+    for (StructuredLogMessage message : new StructuredLogMessage[]{infoMessage, errorMessage}) {
+      assertThat((double) Instant.parse(message.time()).toEpochMilli(),
+          is(closeTo(Instant.now().toEpochMilli(), 30_000)));
+      assertThat(message.styx_component_id(), is(styx_component_id));
+      assertThat(message.styx_workflow_id(), is(styx_workflow_id));
+      assertThat(message.styx_docker_args(), is(styx_docker_args));
+      assertThat(message.styx_docker_image(), is(styx_docker_image));
+      assertThat(message.styx_commit_sha(), is(styx_commit_sha));
+      assertThat(message.styx_parameter(), is(styx_parameter));
+      assertThat(message.styx_execution_id(), is(styx_execution_id));
+      assertThat(message.styx_trigger_id(), is(styx_trigger_id));
+      assertThat(message.styx_trigger_type(), is(styx_trigger_type));
+      assertThat(message.flo_task_id(), is(task.id().toString()));
+      assertThat(message.flo_task_name(), is(task.id().name()));
+      assertThat(message.flo_task_args(), is(task.id().args()));
+    }
+  }
+
+  @Parameters({"true", "false"})
+  @Test
+  public void testTextLoggingProgrammaticSetup(boolean forking) throws Exception {
+    configureForking(forking);
+    StructuredLogging.configureStructuredLogging();
+    verifyTextLogging();
+  }
+
+  @Parameters({"true", "false"})
+  @Test
+  public void testTextLoggingFileSetup(boolean forking) throws Exception {
+    configureForking(forking);
+    configureLogbackFromFile();
+    verifyTextLogging();
+  }
+
+  private void verifyTextLogging() throws Exception {
+
+    final String infoMessageText = "hello world " + UUID.randomUUID();
+    final String errorMessageText = "danger danger! " + UUID.randomUUID();
+
+    final Task<String> task = loggingTask(infoMessageText, errorMessageText);
+    final String exceptionStackTrace = FloRunner.runTask(task)
+        .future().get(30, TimeUnit.SECONDS);
+
+    // Wait for log messages to flush
+    Thread.sleep(1000);
+
+    final String output = stderr.getLog();
+    final String lineSeparator = System.getProperty("line.separator");
+    final List<String> lines = Arrays.asList(output.split(lineSeparator));
+
+    lines.stream()
+        .filter(s -> s.contains("[" + task.id() + "]"))
+        .filter(s -> s.contains("INFO"))
+        .filter(s -> s.contains(infoMessageText))
+        .findAny().orElseThrow(AssertionError::new);
+
+    lines.stream()
+        .filter(s -> s.contains("[" + task.id() + "]"))
+        .filter(s -> s.contains("ERROR"))
+        .filter(s -> s.contains(errorMessageText))
+        .findAny().orElseThrow(AssertionError::new);
+    assertThat(output, containsString(exceptionStackTrace));
+  }
+
+  private Task<String> loggingTask(String infoMessage, String errorMessage) {
+    return Task.named("test", UUID.randomUUID().toString(), 4711).ofType(String.class)
+        .process(() -> {
+          final Logger logger = LoggerFactory.getLogger(StructuredLoggingTest.class);
+          logger.info(infoMessage);
+          final Exception exception = exception();
+          logger.error(errorMessage, exception);
+          return stackTrace(exception);
+        });
+  }
+
+  private static String stackTrace(Throwable t) {
+    final StringWriter sw = new StringWriter();
+    final PrintWriter pw = new PrintWriter(sw);
+    t.printStackTrace(pw);
+    pw.flush();
+    return sw.toString();
+  }
+
+  private static Exception exception() {
+    final Exception exception = new Exception("foo!", new IOException("bar!"));
+    exception.addSuppressed(new RuntimeException("suppressed1", new IllegalStateException("inner suppressed1")));
+    exception.addSuppressed(new RuntimeException("suppressed2", new IllegalStateException("inner suppressed2")));
+    return exception;
+  }
+
+  private void configureForking(boolean forking) {
+    env.set("FLO_FORKING", Boolean.toString(forking));
+  }
+}

--- a/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
+++ b/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
@@ -182,6 +182,35 @@ public class StructuredLoggingTest {
     verifyTextLogging();
   }
 
+  @Test
+  public void testStructuredLoggingWithNoMetadata() throws IOException {
+    // Trigger structured logging
+    final String executionId = UUID.randomUUID().toString();
+    env.set("STYX_EXECUTION_ID", executionId);
+
+    configureLogbackFromFile();
+    final Logger logger = LoggerFactory.getLogger("test");
+    logger.info("hello world!");
+    final String output = stderr.getLog();
+
+    final StructuredLogMessage message = MAPPER.readValue(output, StructuredLogMessage.class);
+
+    assertThat(message.styx_execution_id(), is(executionId));
+    assertThat(message.message(), is("hello world!"));
+
+    assertThat(message.styx_component_id(), is(""));
+    assertThat(message.styx_workflow_id(), is(""));
+    assertThat(message.styx_docker_args(), is(""));
+    assertThat(message.styx_docker_image(), is(""));
+    assertThat(message.styx_commit_sha(), is(""));
+    assertThat(message.styx_parameter(), is(""));
+    assertThat(message.styx_trigger_id(), is(""));
+    assertThat(message.styx_trigger_type(), is(""));
+    assertThat(message.flo_task_id(), is(""));
+    assertThat(message.flo_task_name(), is(""));
+    assertThat(message.flo_task_args(), is(""));
+  }
+
   private void verifyTextLogging() throws Exception {
 
     final String infoMessageText = "hello world " + UUID.randomUUID();

--- a/contrib/flo-styx/src/test/resources/logback.xml
+++ b/contrib/flo-styx/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder class="com.spotify.flo.contrib.styx.StructuredLoggingEncoder"/>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,27 @@
         <artifactId>grpc-context</artifactId>
         <version>1.4.0</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.9.2</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>1.7.25</version>
+      </dependency>
+      <dependency>
+        <groupId>io.norberg</groupId>
+        <artifactId>auto-matter</artifactId>
+        <version>0.15.0</version>
+        <scope>provided</scope>
+      </dependency>
 
       <!-- test dependencies -->
       <dependency>
@@ -152,6 +173,18 @@
         <version>1.18.0</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>io.norberg</groupId>
+        <artifactId>auto-matter-jackson</artifactId>
+        <version>0.15.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>pl.pragmatists</groupId>
+        <artifactId>JUnitParams</artifactId>
+        <version>1.1.1</version>
+        <scope>test</scope>
+      </dependency>
 
       <!-- dependencies of contrib modules -->
       <dependency>
@@ -170,7 +203,7 @@
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -184,7 +217,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Continuation of #84. Can be repurposed on top of another branch/path forward if we choose to.

TODO:
- [x] Test reading task id from grpc context (in-process)