### PR TITLE
Remove processWithContext

### DIFF
--- a/flo-api-generator/src/main/resources/ScalaApi.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApi.mustache
@@ -12,7 +12,6 @@ object FloTask {
 
 trait TaskBuilder0[Z] {
   def process(fn: => Z): Task[Z]
-  def processWithContext(fn: EvalContext => Value[Z]): Task[Z]
   def input[A](task: => Task[A]): TaskBuilder1[A, Z]
   def inputs[A](tasks: => List[Task[A]]): TaskBuilder1[List[A], Z]
 
@@ -23,8 +22,6 @@ trait TaskBuilder0[Z] {
 
 trait TaskBuilder{{arity}}[{{typeArgs}}, Z] {
   def process(fn: ({{typeArgs}}) => Z): Task[Z]
-
-  def processWithContext(fn: EvalContext => ({{typeArgs}}) => Value[Z]): Task[Z]
   {{^iter.isLast}}
 
   def context[{{nextArg}}](taskContextGeneric: TaskContextGeneric[{{nextArg}}]): TaskBuilder{{arityPlus}}[{{typeArgs}}, {{nextArg}}, Z]

--- a/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
+++ b/flo-api-generator/src/main/resources/ScalaApiImpl.mustache
@@ -19,9 +19,6 @@ private[dsl] class Builder0[Z: ClassTag](val name: String, val args: Any*) exten
   override def process(fn: => Z): Task[Z] =
     builder.process(f0(fn))
 
-  override def processWithContext(fn: (EvalContext) => Value[Z]): Task[Z] =
-    builder.processWithContext(f1(fn))
-
   override def context[A1](taskContextGeneric: TaskContextGeneric[A1]): TaskBuilder1[A1, Z] = new Builder1[A1, Z] {
     type J1 = A1
     val c1: J1 => A1 = identity
@@ -63,11 +60,6 @@ private[dsl] trait Builder{{arity}}[{{typeArgsNumA}}, Z] extends TaskBuilder{{ar
   override def process(fn: ({{typeArgsNumA}}) => Z): Task[Z] =
     builder.process(f{{arity}}(
       ({{argumentsNum}}) => fn({{argumentsPsConv}})
-    ))
-
-  override def processWithContext(fn: (EvalContext) => ({{typeArgsNumA}}) => Value[Z]): Task[Z] =
-    builder.processWithContext(f{{arityPlus}}(
-      (ec, {{argumentsNum}}) => fn(ec)({{argumentsPsConv}})
     ))
   {{^iter.isLast}}
 

--- a/flo-api-generator/src/main/resources/TaskBuilder.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilder.mustache
@@ -22,7 +22,6 @@ import com.spotify.flo.EvalContext.Value;
 public interface {{interfaceName}}<Z> {
 
   Task<Z> process(F0<Z> code);
-  Task<Z> processWithContext(F1<EvalContext, EvalContext.Value<Z>> code);
 
   <A> {{interfaceName}}1<A, Z> context(TaskContextGeneric<A> taskContextGeneric);
   <A> {{interfaceName}}1<A, Z> context(TaskContextStrict<A, Z> taskContextStrict);
@@ -33,7 +32,6 @@ public interface {{interfaceName}}<Z> {
 
   interface {{interfaceName}}{{arity}}<{{typeArgs}}, Z> {
     Task<Z> process(F{{arity}}<{{typeArgs}}, Z> code);
-    Task<Z> processWithContext(F{{arityPlus}}<EvalContext, {{typeArgs}}, Value<Z>> code);
   {{^iter.isLast}}
 
     <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> context(TaskContextGeneric<{{nextArg}}> taskContextGeneric);

--- a/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
@@ -9,8 +9,6 @@ import com.spotify.flo.EvalContext.Value;
 import com.spotify.flo.TaskBuilder.*;
 
 import static com.spotify.flo.BuilderUtils.appendToList;
-import static com.spotify.flo.BuilderUtils.gated;
-import static com.spotify.flo.BuilderUtils.gatedVal;
 import static com.spotify.flo.BuilderUtils.lazyFlatten;
 import static com.spotify.flo.BuilderUtils.lazyList;
 import static com.spotify.flo.BuilderUtils.leafEvalFn;
@@ -44,12 +42,10 @@ final class {{implClassName}} {
 
     @Override
     public Task<Z> process(F0<Z> code) {
-      return Task.create(inputs, taskContexts, type, gated(taskId, code::get), taskId);
-    }
-
-    @Override
-    public Task<Z> processWithContext(F1<EvalContext, Value<Z>> code) {
-      return Task.create(inputs, taskContexts, type, gatedVal(taskId, code::apply), taskId);
+      // local ref to drop ref to Builder instance, b/c serialization
+      TaskId taskId = this.taskId;
+      EvalClosure<Z> closure = ec -> ec.invokeProcessFn(taskId, () -> ec.value(code::get));
+      return Task.create(inputs, taskContexts, type, closure, taskId);
     }
 
     @Override
@@ -137,18 +133,6 @@ final class {{implClassName}} {
     }
 
     @Override
-    public Task<Z> processWithContext(F{{arityPlus}}<EvalContext, {{typeArgs}}, Value<Z>> code) {
-      // local ref to drop ref to Builder instance, b/c serialization
-      TaskId taskId = this.taskId;
-      ChainingEval<F{{arity}}<{{typeArgs}}, Value<Z>>, Z> evaluator = this.evaluator;
-
-      EvalClosure<Z> closure = ec -> evaluator.enclose(
-          ({{arguments}}) -> ec.invokeProcessFn(taskId, () -> code.apply(ec, {{arguments}}))
-      ).eval(ec);
-      return Task.create(inputs, taskContexts, type, closure, taskId);
-    }
-
-    @Override
     public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Z> context(TaskContextGeneric<{{nextArg}}> taskContext) {
       return context_(taskContext);
     }
@@ -225,18 +209,6 @@ final class {{implClassName}} {
 
       EvalClosure<Z> closure = ec -> evaluator.enclose(
           ({{lastArguments}}) -> ec.invokeProcessFn(taskId, () -> ec.immediateValue(code.apply({{lastArguments}})))
-      ).eval(ec);
-      return Task.create(inputs, taskContexts, type, closure, taskId);
-    }
-
-    @Override
-    public Task<Z> processWithContext(F{{lastArityPlus}}<EvalContext, {{lastTypeArgs}}, Value<Z>> code) {
-      // local ref to drop ref to Builder instance, b/c serialization
-      TaskId taskId = this.taskId;
-      ChainingEval<F{{lastArity}}<{{lastTypeArgs}}, Value<Z>>, Z> evaluator = this.evaluator;
-
-      EvalClosure<Z> closure = ec -> evaluator.enclose(
-           ({{lastArguments}}) -> ec.invokeProcessFn(taskId, () -> code.apply(ec, {{lastArguments}}))
       ).eval(ec);
       return Task.create(inputs, taskContexts, type, closure, taskId);
     }

--- a/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
@@ -44,7 +44,7 @@ final class {{implClassName}} {
     public Task<Z> process(F0<Z> code) {
       // local ref to drop ref to Builder instance, b/c serialization
       TaskId taskId = this.taskId;
-      EvalClosure<Z> closure = ec -> ec.invokeProcessFn(taskId, () -> ec.value(code::get));
+      EvalClosure<Z> closure = ec -> ec.invokeProcessFn(taskId, code::get);
       return Task.create(inputs, taskContexts, type, closure, taskId);
     }
 
@@ -127,7 +127,7 @@ final class {{implClassName}} {
       ChainingEval<F{{arity}}<{{typeArgs}}, Value<Z>>, Z> evaluator = this.evaluator;
 
       EvalClosure<Z> closure = ec -> evaluator.enclose(
-          ({{arguments}}) -> ec.invokeProcessFn(taskId, () -> ec.value(() -> code.apply({{arguments}})))
+          ({{arguments}}) -> ec.invokeProcessFn(taskId, () -> code.apply({{arguments}}))
       ).eval(ec);
       return Task.create(inputs, taskContexts, type, closure, taskId);
     }
@@ -208,7 +208,7 @@ final class {{implClassName}} {
       ChainingEval<F{{lastArity}}<{{lastTypeArgs}}, Value<Z>>, Z> evaluator = this.evaluator;
 
       EvalClosure<Z> closure = ec -> evaluator.enclose(
-          ({{lastArguments}}) -> ec.invokeProcessFn(taskId, () -> ec.immediateValue(code.apply({{lastArguments}})))
+          ({{lastArguments}}) -> ec.invokeProcessFn(taskId, () -> code.apply({{lastArguments}}))
       ).eval(ec);
       return Task.create(inputs, taskContexts, type, closure, taskId);
     }

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/EvaluatingContext.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/EvaluatingContext.java
@@ -132,7 +132,7 @@ public class EvaluatingContext {
     }
 
     @Override
-    public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+    public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<T> processFn) {
       // todo: only invoke fn if taskId == evalTask
       // todo: fail if called for taskId != evalTask
 

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
@@ -86,7 +86,7 @@ public class PersistingContext extends ForwardingEvalContext {
   }
 
   @Override
-  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<T> processFn) {
     final Promise<T> promise = promise();
     LOG.info("Will not invoke {}", taskId);
     promise.fail(new Persisted());

--- a/flo-workflow/src/main/java/com/spotify/flo/BuilderUtils.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/BuilderUtils.java
@@ -40,16 +40,6 @@ class BuilderUtils {
     return new ChainingEval<>(fClosure);
   }
 
-  static <R> EvalClosure<R> gated(TaskId taskId, Fn<R> code) {
-    return ec -> ec.invokeProcessFn(taskId, () -> ec.value(code));
-  }
-
-  static <R> EvalClosure<R> gatedVal(
-      TaskId taskId,
-      Fn1<EvalContext, Value<R>> code) {
-    return ec -> ec.invokeProcessFn(taskId, () -> code.apply(ec));
-  }
-
   /**
    * Converts an array of {@link Fn}s of {@link Task}s to a {@link Fn} of a list of
    * those tasks {@link Task}s.

--- a/flo-workflow/src/main/java/com/spotify/flo/EvalContext.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/EvalContext.java
@@ -91,9 +91,8 @@ public interface EvalContext {
   }
 
   /**
-   * When called from within any of the functions passed to {@code processWithContext}, this
-   * method will return the {@link Task} currently being processed. Otherwise an empty value
-   * will be returned.
+   * When called during the evaluation of a task, this method will return the {@link Task}
+   * currently being processed. Otherwise an empty value will be returned.
    *
    * <p>The return value of this method is stable for each instance of {@link EvalContext} that is
    * passed into the process functions. Calls from multiple threads will see the same result as

--- a/flo-workflow/src/main/java/com/spotify/flo/EvalContext.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/EvalContext.java
@@ -79,15 +79,16 @@ public interface EvalContext {
    * method, one can intercept the evaluation flow just at the moment between inputs being ready
    * and when the user supplied function for task processing is being invoked.
    *
-   * <p>The default implementation will simply invoke the function immediately.
+   * <p>The default implementation will simply invoke the function immediately inside a
+   * {@link Value} created by {@link #value(Fn)}.
    *
    * @param taskId     The id of the task being invoked
    * @param processFn  A lazily evaluated handle to the process function
    * @param <T>        The task value type
-   * @return The value of the process function invocation
+   * @return The (deferred) value of the process function invocation
    */
-  default <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
-    return processFn.get();
+  default <T> Value<T> invokeProcessFn(TaskId taskId, Fn<T> processFn) {
+    return value(processFn);
   }
 
   /**

--- a/flo-workflow/src/main/java/com/spotify/flo/context/ForwardingEvalContext.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/context/ForwardingEvalContext.java
@@ -43,7 +43,7 @@ public abstract class ForwardingEvalContext implements EvalContext {
   }
 
   @Override
-  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<T> processFn) {
     return delegate.invokeProcessFn(taskId, processFn);
   }
 

--- a/flo-workflow/src/main/java/com/spotify/flo/context/MemoizingContext.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/context/MemoizingContext.java
@@ -210,15 +210,16 @@ public class MemoizingContext extends ForwardingEvalContext {
   }
 
   @Override
-  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<T> processFn) {
     final EvalBundle<T> evalBundle = lookupBundle(taskId);
     final Task<T> task = evalBundle.task;
     final Memoizer<T> memoizer = evalBundle.memoizer;
 
-    return delegate.invokeProcessFn(taskId, () -> processFn.get().map(v -> {
+    return delegate.invokeProcessFn(taskId, () -> {
+      final T v = processFn.get();
       memoizer.store(task, v);
       return v;
-    }));
+    });
   }
 
   /**

--- a/flo-workflow/src/main/java/com/spotify/flo/context/SyncContext.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/context/SyncContext.java
@@ -22,7 +22,7 @@ package com.spotify.flo.context;
 
 import com.spotify.flo.EvalContext;
 import com.spotify.flo.Fn;
-import com.spotify.flo.Task;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Semaphore;
@@ -42,11 +42,6 @@ public class SyncContext implements EvalContext {
 
   public static EvalContext create() {
     return new SyncContext();
-  }
-
-  @Override
-  public <T> Value<T> evaluateInternal(Task<T> task, EvalContext context) {
-    return EvalContext.super.evaluateInternal(task, context);
   }
 
   @Override

--- a/flo-workflow/src/main/java/com/spotify/flo/context/TracingContext.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/context/TracingContext.java
@@ -40,17 +40,18 @@ public class TracingContext extends ForwardingEvalContext {
   public static EvalContext composeWith(EvalContext baseContext) {
     return new TracingContext(baseContext);
   }
-
   @Override
-  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
-    try {
-      return Context.current()
-          .withValue(TASK_ID, taskId)
-          .call(() -> super.invokeProcessFn(taskId, processFn));
-    } catch (RuntimeException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<T> processFn) {
+    return super.invokeProcessFn(taskId, () -> {
+      try {
+        return Context.current()
+            .withValue(TASK_ID, taskId)
+            .call(processFn::get);
+      } catch (RuntimeException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
   }
 }

--- a/flo-workflow/src/test/java/com/spotify/flo/ControlledBlockingContext.java
+++ b/flo-workflow/src/test/java/com/spotify/flo/ControlledBlockingContext.java
@@ -159,15 +159,15 @@ class ControlledBlockingContext implements EvalContext {
   }
 
   @Override
-  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<T> processFn) {
     //noinspection unchecked
     final Interceptor<T> interceptor = (Interceptor<T>) interceptors.get(taskId);
     if (interceptor != null) {
       LOG.info("Intercepting {}", taskId);
-      return interceptor.apply(processFn);
+      return value(() -> interceptor.apply(processFn.get()));
     }
 
-    return processFn.get();
+    return value(processFn);
   }
 
   @Override
@@ -257,6 +257,6 @@ class ControlledBlockingContext implements EvalContext {
   }
 
   @FunctionalInterface
-  interface Interceptor<T> extends F1<Fn<Value<T>>, Value<T>> {
+  interface Interceptor<T> extends F1<T, T> {
   }
 }

--- a/flo-workflow/src/test/java/com/spotify/flo/SerializationTest.java
+++ b/flo-workflow/src/test/java/com/spotify/flo/SerializationTest.java
@@ -58,23 +58,6 @@ public class SerializationTest {
     assertEquals(val.awaitAndGet(), "[9999] hello 10004");
   }
 
-  @Test
-  public void shouldJavaUtilSerializeContextAwareTask() throws Exception {
-    Task<Long> task1 = Task.named("Foo", "Bar", 39).ofType(Long.class)
-        .process(() -> 9999L);
-    Task<String> task2 = Task.named("Baz", 40).ofType(String.class)
-        .input(() -> task1)
-        .inputs(() -> singletonList(task1))
-        .processWithContext((ec, t1, t1l) -> ec.immediateValue(t1l + " hello " + (t1 + 5)));
-
-    serialize(task2);
-    Task<String> des = deserialize();
-    context.evaluate(des).consume(val);
-
-    assertEquals(des.id().name(), "Baz");
-    assertEquals(val.awaitAndGet(), "[9999] hello 10004");
-  }
-
   @Test(expected = NotSerializableException.class)
   public void shouldNotSerializeWithInstanceFieldReference() throws Exception {
     Task<String> task = Task.named("WithRef").ofType(String.class)

--- a/flo-workflow/src/test/java/com/spotify/flo/TaskEvalBehaviorTest.java
+++ b/flo-workflow/src/test/java/com/spotify/flo/TaskEvalBehaviorTest.java
@@ -348,9 +348,9 @@ public class TaskEvalBehaviorTest {
 
     // gating mechanism used in ControlledBlockingContext to implement intercepts
     ControlledBlockingContext context = new ControlledBlockingContext();
-    context.intercept(task, valueFn -> {
+    context.intercept(task, done -> {
       intercepted.set(true);
-      return valueFn.get().map(done -> "!!" + done + "!!");
+      return "!!" + done + "!!";
     });
 
     AwaitValue<String> val = new AwaitValue<>();

--- a/flo-workflow/src/test/java/com/spotify/flo/TaskTest.java
+++ b/flo-workflow/src/test/java/com/spotify/flo/TaskTest.java
@@ -30,8 +30,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import com.spotify.flo.EvalContext.Promise;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 public class TaskTest {
@@ -63,17 +61,16 @@ public class TaskTest {
   }
 
   //  Naming convention for tests
-  //  XXX
-  //  ^^^
-  //  |||
-  //  ||`----> D,C = direct, context
+  //  XX
+  //  ^^
+  //  ||
   //  |`-----> I,L = in, ins
   //  `------> arity
   //    eg 2RD_IL = arity 2 curried direct processed task with single input and list input
   // 0. ===========================================================================================
 
   @Test
-  public void shouldEvaluate0ND() throws Exception {
+  public void shouldEvaluate0N() throws Exception {
     Task<String> task = Task.named("InContext").ofType(String.class)
         .process(() -> "constant");
 
@@ -87,22 +84,10 @@ public class TaskTest {
     assertThat(val.awaitAndGet(), is("constant"));
   }
 
-  @Test
-  public void shouldEvaluate0NC() throws Exception {
-    AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").ofType(String.class).processWithContext(ec -> {
-      Promise<String> promise = ec.promise();
-      promiseRef.set(promise);
-      return promise.value();
-    });
-
-    validatePromiseEvaluation(task, promiseRef, "");
-  }
-
   // 1. ===========================================================================================
 
   @Test
-  public void shouldEvaluate1ND_I() throws Exception {
+  public void shouldEvaluate1N_I() throws Exception {
     Task<String> task = Task.named("InContext").ofType(String.class)
         .input(() -> leaf("A"))
         .process((a) -> "done: " + a);
@@ -111,7 +96,7 @@ public class TaskTest {
   }
 
   @Test
-  public void shouldEvaluate1ND_L() throws Exception {
+  public void shouldEvaluate1N_L() throws Exception {
     Task<String> task = Task.named("InContext").ofType(String.class)
         .inputs(() -> asList(leaf("A"), leaf("B")))
         .process((ab) -> "done: " + ab);
@@ -119,38 +104,10 @@ public class TaskTest {
     validateEvaluation(task, "done: [A, B]", leaf("A"), leaf("B"));
   }
 
-  @Test
-  public void shouldEvaluate1NC_I() throws Exception {
-    AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").ofType(String.class)
-        .input(() -> leaf("A"))
-        .processWithContext((ec, a) -> {
-          Promise<String> promise = ec.promise();
-          promiseRef.set(promise);
-          return promise.value().map(v -> v + " - " + a);
-        });
-
-    validatePromiseEvaluation(task, promiseRef, " - A", leaf("A"));
-  }
-
-  @Test
-  public void shouldEvaluate1NC_L() throws Exception {
-    AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").ofType(String.class)
-        .inputs(() -> asList(leaf("A"), leaf("B")))
-        .processWithContext((ec, ab) -> {
-          Promise<String> promise = ec.promise();
-          promiseRef.set(promise);
-          return promise.value().map(v -> v + " - " + ab);
-        });
-
-    validatePromiseEvaluation(task, promiseRef, " - [A, B]", leaf("A"), leaf("B"));
-  }
-
   // 2. ===========================================================================================
 
   @Test
-  public void shouldEvaluate2ND_II() throws Exception {
+  public void shouldEvaluate2N_II() throws Exception {
     Task<String> task = Task.named("InContext").ofType(String.class)
         .input(() -> leaf("A"))
         .input(() -> leaf("B"))
@@ -160,7 +117,7 @@ public class TaskTest {
   }
 
   @Test
-  public void shouldEvaluate2ND_IL() throws Exception {
+  public void shouldEvaluate2N_IL() throws Exception {
     Task<String> task = Task.named("InContext").ofType(String.class)
         .input(() -> leaf("A"))
         .inputs(() -> asList(leaf("B"), leaf("C")))
@@ -169,40 +126,10 @@ public class TaskTest {
     validateEvaluation(task, "done: A - [B, C]", leaf("A"), leaf("B"), leaf("C"));
   }
 
-  @Test
-  public void shouldEvaluate2NC_II() throws Exception {
-    AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").ofType(String.class)
-        .input(() -> leaf("A"))
-        .input(() -> leaf("B"))
-        .processWithContext((ec, a, b) -> {
-          Promise<String> promise = ec.promise();
-          promiseRef.set(promise);
-          return promise.value().map(v -> v + " - " + a + " - " + b);
-        });
-
-    validatePromiseEvaluation(task, promiseRef, " - A - B", leaf("A"), leaf("B"));
-  }
-
-  @Test
-  public void shouldEvaluate2NC_IL() throws Exception {
-    AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").ofType(String.class)
-        .input(() -> leaf("A"))
-        .inputs(() -> asList(leaf("B"), leaf("C")))
-        .processWithContext((ec, a, bc) -> {
-          Promise<String> promise = ec.promise();
-          promiseRef.set(promise);
-          return promise.value().map(v -> v + " - " + a + " - " + bc);
-        });
-
-    validatePromiseEvaluation(task, promiseRef, " - A - [B, C]", leaf("A"), leaf("B"), leaf("C"));
-  }
-
   // 3. ===========================================================================================
 
   @Test
-  public void shouldEvaluate3ND_III() throws Exception {
+  public void shouldEvaluate3N_III() throws Exception {
     Task<String> task = Task.named("InContext").ofType(String.class)
         .input(() -> leaf("A"))
         .input(() -> leaf("B"))
@@ -213,7 +140,7 @@ public class TaskTest {
   }
 
   @Test
-  public void shouldEvaluate3ND_IIL() throws Exception {
+  public void shouldEvaluate3N_IIL() throws Exception {
     Task<String> task = Task.named("InContext").ofType(String.class)
         .input(() -> leaf("A"))
         .input(() -> leaf("B"))
@@ -221,39 +148,6 @@ public class TaskTest {
         .process((a, b, cd) -> "done: " + a + " - " + b +" - " + cd);
 
     validateEvaluation(task, "done: A - B - [C, D]", leaf("A"), leaf("B"), leaf("C"), leaf("D"));
-  }
-
-  @Test
-  public void shouldEvaluate3NC_III() throws Exception {
-    AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").ofType(String.class)
-        .input(() -> leaf("A"))
-        .input(() -> leaf("B"))
-        .input(() -> leaf("C"))
-        .processWithContext((ec, a, b, c) -> {
-          Promise<String> promise = ec.promise();
-          promiseRef.set(promise);
-          return promise.value().map(v -> v + " - " + a + " - " + b +" - " + c);
-        });
-
-    validatePromiseEvaluation(task, promiseRef, " - A - B - C", leaf("A"), leaf("B"), leaf("C"));
-  }
-
-  @Test
-  public void shouldEvaluate3NC_IIL() throws Exception {
-    AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").ofType(String.class)
-        .input(() -> leaf("A"))
-        .input(() -> leaf("B"))
-        .inputs(() -> asList(leaf("C"), leaf("D")))
-        .processWithContext((ec, a, b, cd) -> {
-          Promise<String> promise = ec.promise();
-          promiseRef.set(promise);
-          return promise.value().map(v -> v + " - " + a + " - " + b +" - " + cd);
-        });
-
-    validatePromiseEvaluation(task, promiseRef, " - A - B - [C, D]", leaf("A"), leaf("B"),
-                              leaf("C"), leaf("D"));
   }
 
   // ==============================================================================================
@@ -308,41 +202,7 @@ public class TaskTest {
     assertThat(val.awaitAndGet(), is(expectedOutput));
   }
 
-  private void validatePromiseEvaluation(
-      Task<String> task,
-      AtomicReference<Promise<String>> promiseRef,
-      String expectedOutput,
-      Task... inputs)
-      throws InterruptedException {
-
-    AwaitValue<String> val = new AwaitValue<>();
-    ControlledBlockingContext context = new ControlledBlockingContext();
-    context.evaluate(task).consume(val);
-
-    context.waitFor(task);
-    context.release(task);
-    context.waitUntilNumConcurrent(inputs.length + 1); // task + inputs
-    for (Task input : inputs) {
-      assertTrue(context.isWaiting(input));
-    }
-    assertFalse(val.isAvailable());
-
-    for (Task input : inputs) {
-      context.release(input);
-    }
-    context.waitUntilNumConcurrent(1); // task will not complete, promise still waiting
-    assertFalse(val.isAvailable());
-
-    //noinspection StatementWithEmptyBody
-    while (promiseRef.get() == null) {
-    }
-
-    promiseRef.get().set("done: from here");
-    context.waitUntilNumConcurrent(0);
-    assertThat(val.awaitAndGet(), is("done: from here" + expectedOutput));
-  }
-
-  Task<String> leaf(String s) {
+  private Task<String> leaf(String s) {
     return Task.named("Leaf", s).ofType(String.class).process(() -> s);
   }
 }

--- a/flo-workflow/src/test/java/com/spotify/flo/context/AsyncContextFailurePropagationTest.java
+++ b/flo-workflow/src/test/java/com/spotify/flo/context/AsyncContextFailurePropagationTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertThat;
 
 import com.spotify.flo.AwaitValue;
 import com.spotify.flo.EvalContext;
-import com.spotify.flo.EvalContext.Promise;
 import com.spotify.flo.Task;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -38,10 +37,8 @@ public class AsyncContextFailurePropagationTest {
   @Test
   public void shouldFailTaskIfUpstreamsFail() throws Exception {
     Task<String> failingUpstream = Task.named("Failing").ofType(String.class)
-        .processWithContext(ec -> {
-          final Promise<String> promise = ec.promise();
-          promise.fail(new RuntimeException("failed"));
-          return promise.value();
+        .process(() -> {
+          throw new RuntimeException("failed");
         });
 
     AtomicInteger count = new AtomicInteger(0);

--- a/flo-workflow/src/test/java/com/spotify/flo/context/AsyncContextTest.java
+++ b/flo-workflow/src/test/java/com/spotify/flo/context/AsyncContextTest.java
@@ -284,7 +284,7 @@ public class AsyncContextTest {
     // #invokeProcessFn()
     {
       final CompletableFuture<String> future = new CompletableFuture<>();
-      final Fn<Value<String>> processFn = () -> context.immediateValue(key.get());
+      final Fn<String> processFn = key::get;
       grpcContext.call(() -> context.invokeProcessFn(TaskId.create("test"), processFn)).consume(future::complete);
       assertThat(future.get(30, TimeUnit.SECONDS), is(value));
     }

--- a/flo-workflow/src/test/java/com/spotify/flo/context/MemoizingContextTest.java
+++ b/flo-workflow/src/test/java/com/spotify/flo/context/MemoizingContextTest.java
@@ -64,7 +64,7 @@ public class MemoizingContextTest {
   }
 
   @Test(expected = IllegalStateException.class)
-  public void evaluatesButFailsToStore() throws InterruptedException {
+  public void evaluatesButFailsToStore() throws Throwable {
     context = MemoizingContext.builder(sync())
         .memoizer(new MemoizingContext.Memoizer<ExampleValue>() {
           @Override
@@ -81,7 +81,9 @@ public class MemoizingContextTest {
         })
         .build();
 
-    context.evaluate(example(7));
+    AwaitValue<Throwable> await = new AwaitValue<>();
+    context.evaluate(example(7)).onFail(await);
+    throw await.awaitAndGet();
   }
 
   @Test


### PR DESCRIPTION
Related to discussions around #84 

Removed the (mostly unused) `processWithContext` builder method, with the goal of removing the async call-frame indirection that was imposed on `EvalContext.invokeProcessFn`.

The result of this PR should be that the `Fn<T> processFn` passed into `EvalContext.invokeProcessFn` should actually be the user code, which should allow the context to decide how to invoke it without any `Value<T>` instances being created inside.