### PR TITLE
fix forking for scala 2.11 - redux

### DIFF
--- a/flo-freezer/pom.xml
+++ b/flo-freezer/pom.xml
@@ -22,5 +22,9 @@
       <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo-shaded</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill-java</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
@@ -99,6 +99,7 @@ public class PersistingContext extends ForwardingEvalContext {
     kryo.register(java.lang.invoke.SerializedLambda.class);
     kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
     kryo.addDefaultSerializer(java.lang.Throwable.class, new JavaSerializer());
+    kryo.getFieldSerializerConfig().setIgnoreSyntheticFields(false);
 
     if (Files.exists(file)) {
       throw new RuntimeException("File " + file + " already exists");
@@ -119,6 +120,7 @@ public class PersistingContext extends ForwardingEvalContext {
     kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
     kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
     kryo.addDefaultSerializer(java.lang.Throwable.class, new JavaSerializer());
+    kryo.getFieldSerializerConfig().setIgnoreSyntheticFields(false);
 
     try (Input input = new Input(newInputStream(filePath))) {
       return (T) kryo.readClassAndObject(input);

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
@@ -35,6 +35,7 @@ import com.spotify.flo.Fn;
 import com.spotify.flo.Task;
 import com.spotify.flo.TaskId;
 import com.spotify.flo.context.ForwardingEvalContext;
+import com.twitter.chill.java.PackageRegistrar;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -96,6 +97,7 @@ public class PersistingContext extends ForwardingEvalContext {
 
   public static void serialize(Object object, Path file) throws Exception{
     final Kryo kryo = new Kryo();
+    PackageRegistrar.all().apply(kryo);
     kryo.register(java.lang.invoke.SerializedLambda.class);
     kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
     kryo.addDefaultSerializer(java.lang.Throwable.class, new JavaSerializer());
@@ -116,6 +118,7 @@ public class PersistingContext extends ForwardingEvalContext {
 
   public static <T> T deserialize(Path filePath) throws Exception {
     Kryo kryo = new Kryo();
+    PackageRegistrar.all().apply(kryo);
     kryo.register(java.lang.invoke.SerializedLambda.class);
     kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
     kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));

--- a/flo-scala_2.11/pom.xml
+++ b/flo-scala_2.11/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>flo-runner</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.baseVersion}</artifactId>
       <version>3.0.4</version>

--- a/flo-scala_2.12/pom.xml
+++ b/flo-scala_2.12/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>flo-runner</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.baseVersion}</artifactId>
       <version>3.0.4</version>

--- a/flo-scala_2.12/src/test/resources/logback.xml
+++ b/flo-scala_2.12/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDERR" />
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
         <version>4.0.0</version>
       </dependency>
       <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>chill-java</artifactId>
+        <version>0.9.2</version>
+      </dependency>
+      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-context</artifactId>
         <version>1.4.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,11 @@
         <artifactId>jsr305</artifactId>
         <version>3.0.1</version>
       </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Alternative to #91 

Instead of using experimental compiler flags, configure kryo to include synthetic fields. 

I think the root cause of our problem was that kryo would drop some synthetic fields in the ScalaApi TaskBuilder & friends. `*waving hands a bit*`