### PR TITLE
Add ConfigSerializer to PersistingContext

### DIFF
--- a/flo-freezer/pom.xml
+++ b/flo-freezer/pom.xml
@@ -26,5 +26,9 @@
       <groupId>com.twitter</groupId>
       <artifactId>chill-java</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/ConfigSerializer.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/ConfigSerializer.java
@@ -1,0 +1,49 @@
+/*-
+ * -\-\-
+ * flo-freezer
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.freezer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.MapSerializer;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConfigSerializer extends Serializer<Config> {
+
+  @Override
+  public void write(Kryo kryo, Output output, Config object) {
+    MapSerializer serializer = new MapSerializer();
+    kryo.writeObject(output, object.root().unwrapped(), serializer);
+  }
+
+  @Override
+  public Config read(Kryo kryo, Input input, Class<Config> type) {
+    MapSerializer serializer = new MapSerializer();
+    Map configMap = kryo.readObject(input, HashMap.class, serializer);
+    return ConfigFactory.parseMap(configMap);
+  }
+
+}

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
@@ -37,6 +37,8 @@ import com.spotify.flo.TaskId;
 import com.spotify.flo.context.ForwardingEvalContext;
 import com.twitter.chill.java.PackageRegistrar;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -127,6 +129,11 @@ public class PersistingContext extends ForwardingEvalContext {
     Kryo kryo = new Kryo();
     PackageRegistrar.all().apply(kryo);
     kryo.register(java.lang.invoke.SerializedLambda.class);
+    try {
+      kryo.register(Class.forName("com.typesafe.config.impl.SimpleConfig"), new ConfigSerializer());
+    } catch (ClassNotFoundException e) {
+      LOG.debug("ConfigSerializer not registered", e);
+    }
     kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
     kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
     kryo.addDefaultSerializer(Throwable.class, new JavaSerializer());

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
@@ -95,39 +95,43 @@ public class PersistingContext extends ForwardingEvalContext {
     return promise.value();
   }
 
-  public static void serialize(Object object, Path file) throws Exception{
-    final Kryo kryo = new Kryo();
-    PackageRegistrar.all().apply(kryo);
-    kryo.register(java.lang.invoke.SerializedLambda.class);
-    kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
-    kryo.addDefaultSerializer(java.lang.Throwable.class, new JavaSerializer());
-    kryo.getFieldSerializerConfig().setIgnoreSyntheticFields(false);
-
-    if (Files.exists(file)) {
-      throw new RuntimeException("File " + file + " already exists");
-    }
-
+  public static void serialize(Object object, Path file) throws Exception {
     try {
-      try (Output output = new Output(newOutputStream(file, WRITE, CREATE_NEW))) {
-        kryo.writeClassAndObject(output, object);
-      }
+      serialize(object, Files.newOutputStream(file, WRITE, CREATE_NEW));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
+  public static void serialize(Object object, OutputStream outputStream) {
+    final Kryo kryo = getKryo();
+
+    try (Output output = new Output(outputStream)) {
+      kryo.writeClassAndObject(output, object);
+    }
+  }
+
   public static <T> T deserialize(Path filePath) throws Exception {
+    return deserialize(Files.newInputStream(filePath));
+  }
+
+  public static <T> T deserialize(InputStream inputStream) {
+    final Kryo kryo = getKryo();
+
+    try (Input input = new Input(inputStream)) {
+      return (T) kryo.readClassAndObject(input);
+    }
+  }
+
+  private static Kryo getKryo() {
     Kryo kryo = new Kryo();
     PackageRegistrar.all().apply(kryo);
     kryo.register(java.lang.invoke.SerializedLambda.class);
     kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
     kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
-    kryo.addDefaultSerializer(java.lang.Throwable.class, new JavaSerializer());
+    kryo.addDefaultSerializer(Throwable.class, new JavaSerializer());
     kryo.getFieldSerializerConfig().setIgnoreSyntheticFields(false);
-
-    try (Input input = new Input(newInputStream(filePath))) {
-      return (T) kryo.readClassAndObject(input);
-    }
+    return kryo;
   }
 
   public static String cleanForFilename(TaskId taskId) {

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
@@ -20,8 +20,6 @@
 
 package com.spotify.flo.freezer;
 
-import static java.nio.file.Files.newInputStream;
-import static java.nio.file.Files.newOutputStream;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.nio.file.StandardOpenOption.WRITE;
 
@@ -131,6 +129,7 @@ public class PersistingContext extends ForwardingEvalContext {
     PackageRegistrar.all().apply(kryo);
     kryo.register(java.lang.invoke.SerializedLambda.class);
     try {
+      // SimpleConfig is a package private class, hence using Class.forName to reference it
       kryo.register(Class.forName("com.typesafe.config.impl.SimpleConfig"), new ConfigSerializer());
     } catch (ClassNotFoundException e) {
       LOG.debug("ConfigSerializer not registered", e);

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/PersistingContext.java
@@ -119,6 +119,7 @@ public class PersistingContext extends ForwardingEvalContext {
 
   public static <T> T deserialize(InputStream inputStream) {
     final Kryo kryo = getKryo();
+    kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
 
     try (Input input = new Input(inputStream)) {
       return (T) kryo.readClassAndObject(input);
@@ -126,7 +127,7 @@ public class PersistingContext extends ForwardingEvalContext {
   }
 
   private static Kryo getKryo() {
-    Kryo kryo = new Kryo();
+    final Kryo kryo = new Kryo();
     PackageRegistrar.all().apply(kryo);
     kryo.register(java.lang.invoke.SerializedLambda.class);
     try {
@@ -135,7 +136,6 @@ public class PersistingContext extends ForwardingEvalContext {
       LOG.debug("ConfigSerializer not registered", e);
     }
     kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
-    kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
     kryo.addDefaultSerializer(Throwable.class, new JavaSerializer());
     kryo.getFieldSerializerConfig().setIgnoreSyntheticFields(false);
     return kryo;


### PR DESCRIPTION
I think I found an issue with flo, kryo and typesafe/lightbend Config serialization:
> "ConfigObject is immutable, you can't call Map.put"
https://github.com/twitter/chill/issues/265

The solution is to create and register a serializer for SimpleConfig class.
This PR adds the serializer on flo-freezer.
Still, I think it might be questionable to add a serializer here upstream. For Config it might generic and worth. But I wonder if later flo should allow users to register their own serializers. 