### PR TITLE
add NotRetriable (exit code 50) exception

### DIFF
--- a/flo-runner/src/main/java/com/spotify/flo/context/FloRunner.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/FloRunner.java
@@ -29,6 +29,7 @@ import com.spotify.flo.TaskInfo;
 import com.spotify.flo.freezer.Persisted;
 import com.spotify.flo.freezer.PersistingContext;
 import com.spotify.flo.status.NotReady;
+import com.spotify.flo.status.NotRetriable;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.io.Closeable;
@@ -288,6 +289,8 @@ public final class FloRunner<T> {
         final int status;
         if (e.getCause() instanceof NotReady) {
           status = 20;
+        } else if (e.getCause() instanceof NotRetriable) {
+          status = 50;
         } else if (e.getCause() instanceof Persisted) {
           status = 0;
         } else {

--- a/flo-runner/src/main/java/com/spotify/flo/status/NotRetriable.java
+++ b/flo-runner/src/main/java/com/spotify/flo/status/NotRetriable.java
@@ -1,0 +1,27 @@
+/*-
+ * -\-\-
+ * flo runner
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.status;
+
+/**
+ * Signals that a task has failed and should not be retried.
+ */
+public class NotRetriable extends TaskStatusException {
+}

--- a/flo-runner/src/test/java/com/spotify/flo/context/FloRunnerTest.java
+++ b/flo-runner/src/test/java/com/spotify/flo/context/FloRunnerTest.java
@@ -44,6 +44,7 @@ import com.spotify.flo.context.FloRunner.Result;
 import com.spotify.flo.freezer.Persisted;
 import com.spotify.flo.freezer.PersistingContext;
 import com.spotify.flo.status.NotReady;
+import com.spotify.flo.status.NotRetriable;
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -230,6 +231,20 @@ public class FloRunnerTest {
     runTask(task).waitAndExit(status::set);
 
     assertThat(status.get(), is(20));
+  }
+
+  @Test
+  public void notRetriableExitsFifty() {
+    final Task<String> task = Task.named("task").ofType(String.class)
+        .process(() -> {
+          throw new NotRetriable();
+        });
+
+    AtomicInteger status = new AtomicInteger();
+
+    runTask(task).waitAndExit(status::set);
+
+    assertThat(status.get(), is(50));
   }
 
   @Test


### PR DESCRIPTION
Allow a task to signal that it failed and should not be retried.