### PR TITLE
Fix scala type check

### DIFF
--- a/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioOperator.scala
+++ b/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioOperator.scala
@@ -35,10 +35,9 @@ class ScioOperator extends TaskOperator[ScioJobSpec.Provider] {
 }
 
 object ScioOperator {
-  private val supplier = new F0[Mocking] {
+  private val MOCK = TestContext.key("mock", new F0[Mocking](){
     override def get(): Mocking = new Mocking
-  }
-  private val MOCK = TestContext.key("mock", supplier)
+  })
 
   def mock(): Mocking = {
     MOCK.get()

--- a/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioOperator.scala
+++ b/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioOperator.scala
@@ -20,6 +20,7 @@
 
 package com.spotify.flo.contrib.scio
 
+import com.spotify.flo.TaskBuilder.F0
 import com.spotify.flo.{EvalContext, TaskId, TaskOperator, TestContext}
 import com.spotify.scio.testing.JobTest
 import com.spotify.scio.testing.JobTest.BeamOptions
@@ -34,7 +35,10 @@ class ScioOperator extends TaskOperator[ScioJobSpec.Provider] {
 }
 
 object ScioOperator {
-  private val MOCK = TestContext.key("mock", () => new Mocking())
+  private val supplier = new F0[Mocking] {
+    override def get(): Mocking = new Mocking
+  }
+  private val MOCK = TestContext.key("mock", supplier)
 
   def mock(): Mocking = {
     MOCK.get()

--- a/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioOperator.scala
+++ b/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioOperator.scala
@@ -35,7 +35,7 @@ class ScioOperator extends TaskOperator[ScioJobSpec.Provider] {
 }
 
 object ScioOperator {
-  private val MOCK = TestContext.key("mock", new F0[Mocking](){
+  private val MOCK = TestContext.key("mock", new F0[Mocking] {
     override def get(): Mocking = new Mocking
   })
 


### PR DESCRIPTION
Running mvn scala:doc-jar gave the error:

```
ScioOperator.scala:37: error: overloaded method value key with alternatives:
14:02:22 [INFO]   [T](x$1: String, x$2: com.spotify.flo.TaskBuilder.F0[T])com.spotify.flo.TestContext.Key[T] <and>
14:02:22 [INFO]   [T](x$1: String)com.spotify.flo.TestContext.Key[T]
14:02:22 [INFO]  cannot be applied to (String, () => com.spotify.flo.contrib.scio.ScioOperator.Mocking)
14:02:22 [INFO]   private val MOCK = TestContext.key("mock", () => new Mocking())
```
Explicitly declaring the lambda as a `TaskBuilder.F0` type fixes that