### PR TITLE
fix scalac args & fix scaladoc

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,6 @@ dependencies:
 
 test:
   override:
-    - mvn verify --batch-mode -Pcoverage
+    - mvn verify scala:doc-jar --batch-mode -Pcoverage
   post:
     - bash <(curl -s https://codecov.io/bash)

--- a/contrib/flo-scio_2.11/pom.xml
+++ b/contrib/flo-scio_2.11/pom.xml
@@ -84,7 +84,10 @@
           <sourceDir>../flo-scio_2.12/src/main/scala</sourceDir>
           <scalaVersion>${scala.version}</scalaVersion>
           <sendJavaToScalac>false</sendJavaToScalac>
-          <addScalacArgs>-Xexperimental|-target:jvm-1.8</addScalacArgs>
+          <args>
+            <arg>-Xexperimental</arg>
+            <arg>-target:jvm-1.8</arg>
+          </args>
         </configuration>
       </plugin>
 

--- a/flo-scala_2.11/pom.xml
+++ b/flo-scala_2.11/pom.xml
@@ -63,7 +63,10 @@
           <sourceDir>../flo-scala_2.12/src/main/scala</sourceDir>
           <scalaVersion>${scala.version}</scalaVersion>
           <sendJavaToScalac>false</sendJavaToScalac>
-          <addScalacArgs>-Xexperimental|-target:jvm-1.8</addScalacArgs>
+          <args>
+            <arg>-Xexperimental</arg>
+            <arg>-target:jvm-1.8</arg>
+          </args>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
`addScalacArgs` is not picked up by `doc-jar` mojo but `args` is.'

Also have circleci test `scala:doc-jar` to catch this kind of breakage earlier in the future.