### PR TITLE
wip: Mock StagingTableId's in flo-bigquery

### DIFF
--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/DefaultBigQueryClient.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/DefaultBigQueryClient.java
@@ -59,6 +59,14 @@ public class DefaultBigQueryClient implements FloBigQueryClient {
   }
 
   @Override
+  public StagingTableId createStagingTableId(BigQueryContext context, TableId tableId) {
+    return StagingTableId.of(
+        context,
+        TableId.of(tableId.getProject(), "_incoming_", tableId.getTable())
+    );
+  }
+
+  @Override
   public void publish(StagingTableId stagingTableId, TableId tableId) {
     final TableId staging = stagingTableId.tableId();
     LOG.debug("copying staging table {} to {}", staging, tableId);

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/FloBigQueryClient.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/FloBigQueryClient.java
@@ -53,4 +53,9 @@ public interface FloBigQueryClient {
    * @return true if it exists, otherwise false
    */
   boolean tableExists(TableId tableId);
+
+  /**
+   * Create a {@link StagingTableId} for {@param tableId}
+   */
+  StagingTableId createStagingTableId(BigQueryContext context, TableId tableId);
 }

--- a/contrib/flo-bigquery/src/test/java/com/spotify/flo/contrib/bigquery/BigQueryMockingTest.java
+++ b/contrib/flo-bigquery/src/test/java/com/spotify/flo/contrib/bigquery/BigQueryMockingTest.java
@@ -28,7 +28,9 @@ import com.spotify.flo.FloTesting;
 import com.spotify.flo.Task;
 import com.spotify.flo.TestScope;
 import com.spotify.flo.context.FloRunner;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
 public class BigQueryMockingTest {
@@ -91,6 +93,40 @@ public class BigQueryMockingTest {
       assertThat(tableId, is(expected));
       assertThat(BigQueryMocking.mock().tableExists(expected), is(true));
       assertThat(BigQueryMocking.mock().tablePublished(expected), is(true));
+    }
+  }
+
+  @Test
+  public void shouldCreateCustomStagingTableId()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    final TableId expectedFinal = TableId.of("foo", "bar", "tab");
+    final TableId expectedStaging = TableId.of("test_foo", "test_bar", "test_tab");
+
+
+    final Task<TableId> task = Task.named("task")
+        .ofType(TableId.class)
+        .context(BigQueryContext.create(expectedFinal))
+        .process(actual -> {
+          assertThat(actual.tableId(), is(expectedStaging));
+          return actual.publish();
+        });
+
+    try(final TestScope scope = FloTesting.scope()){
+      BigQueryMocking.mock().stagingTableId(expectedFinal, expectedStaging);
+
+      assertThat(BigQueryMocking.mock().tableExists(expectedFinal), is(false));
+      assertThat(BigQueryMocking.mock().tablePublished(expectedFinal), is(false));
+      assertThat(BigQueryMocking.mock().tableExists(expectedStaging), is(true));
+      assertThat(BigQueryMocking.mock().tablePublished(expectedStaging), is(false));
+
+      final TableId resultTableId = FloRunner.runTask(task).future().get(30, TimeUnit.SECONDS);
+
+      assertThat(resultTableId, is(expectedFinal));
+      assertThat(BigQueryMocking.mock().tableExists(expectedFinal), is(true));
+      assertThat(BigQueryMocking.mock().tablePublished(expectedFinal), is(true));
+
+      assertThat(BigQueryMocking.mock().tableExists(expectedStaging), is(false));
+      assertThat(BigQueryMocking.mock().tablePublished(expectedStaging), is(false));
     }
   }
 }


### PR DESCRIPTION
A test like 
```
      ScioOperator.mock().jobTest(task.id())(_
        .input(
          BigQueryIO[SpecData.EndContent](
           getQuery(inputTableId)),
          SpecData.fakeInput)
        .output(
          BigQueryIO[SpecData.OutputType](stagingTableId))
        (x =>
          x should containInAnyOrder(SpecData.OutputType))
      )
```

Requires an the `stagingTableId` to be known to the user, cos `.output(..)` seems to get called before `ScioOperator.success` therefore the result data is expected to be in the intermediate staging table.