### PR TITLE
bigquery operator

### DIFF
--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryClientSingleton.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryClientSingleton.java
@@ -26,28 +26,31 @@ import com.spotify.flo.FloTesting;
 
 class BigQueryClientSingleton {
 
-  static final BigQuery BIGQUERY_INTERNAL;
-  static final FloBigQueryClient BIGQUERY_CLIENT;
+  private static class Holder {
 
-  static {
-    final BigQueryOptions.Builder bigquery = BigQueryOptions.newBuilder();
-    // Work around a bug in ServiceOptions.getDefaultProjectId() where it will use the project
-    // returned by the GCE metadata server instead of the service account project
-    // https://github.com/GoogleCloudPlatform/google-cloud-java/pull/2304/files#diff-966eb51fcb59c92eb46ebd5f532d8e52R404
-    // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/3533
-    final String projectId = GcpOptions.getDefaultProjectId();
-    if (projectId != null) {
-      bigquery.setProjectId(projectId);
+    private static final BigQuery BIGQUERY_INTERNAL;
+    private static final FloBigQueryClient BIGQUERY_CLIENT;
+
+    static {
+      final BigQueryOptions.Builder bigquery = BigQueryOptions.newBuilder();
+      // Work around a bug in ServiceOptions.getDefaultProjectId() where it will use the project
+      // returned by the GCE metadata server instead of the service account project
+      // https://github.com/GoogleCloudPlatform/google-cloud-java/pull/2304/files#diff-966eb51fcb59c92eb46ebd5f532d8e52R404
+      // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/3533
+      final String projectId = GcpOptions.getDefaultProjectId();
+      if (projectId != null) {
+        bigquery.setProjectId(projectId);
+      }
+      BIGQUERY_INTERNAL = bigquery.build().getService();
+      BIGQUERY_CLIENT = new DefaultBigQueryClient(BIGQUERY_INTERNAL);
     }
-    BIGQUERY_INTERNAL = bigquery.build().getService();
-    BIGQUERY_CLIENT = new DefaultBigQueryClient(BIGQUERY_INTERNAL);
   }
 
   static FloBigQueryClient bq() {
     if (FloTesting.isTest()) {
       return BigQueryMocking.mock().client();
     } else {
-      return BIGQUERY_CLIENT;
+      return Holder.BIGQUERY_CLIENT;
     }
   }
 }

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryClientSingleton.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryClientSingleton.java
@@ -22,10 +22,11 @@ package com.spotify.flo.contrib.bigquery;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.spotify.flo.FloTesting;
 
 class BigQueryClientSingleton {
 
-  private static final BigQuery BIGQUERY_INTERNAL;
+  static final BigQuery BIGQUERY_INTERNAL;
   static final FloBigQueryClient BIGQUERY_CLIENT;
 
   static {
@@ -40,5 +41,13 @@ class BigQueryClientSingleton {
     }
     BIGQUERY_INTERNAL = bigquery.build().getService();
     BIGQUERY_CLIENT = new DefaultBigQueryClient(BIGQUERY_INTERNAL);
+  }
+
+  static FloBigQueryClient bq() {
+    if (FloTesting.isTest()) {
+      return BigQueryMocking.mock().client();
+    } else {
+      return BIGQUERY_CLIENT;
+    }
   }
 }

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryContext.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryContext.java
@@ -24,7 +24,6 @@ import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.TableId;
 import com.spotify.flo.EvalContext;
-import com.spotify.flo.FloTesting;
 import com.spotify.flo.Task;
 import com.spotify.flo.TaskBuilder.F0;
 import com.spotify.flo.TaskContextStrict;
@@ -52,7 +51,7 @@ public class BigQueryContext extends TaskContextStrict<StagingTableId, TableId> 
   }
 
   public static BigQueryContext create(TableId tableId) {
-    return create(BigQueryContext::defaultBigQuerySupplier, tableId);
+    return create(BigQueryClientSingleton::bq, tableId);
   }
 
   static BigQueryContext create(F0<FloBigQueryClient> bigQuerySupplier, TableId tableId) {
@@ -124,11 +123,4 @@ public class BigQueryContext extends TaskContextStrict<StagingTableId, TableId> 
   }
 
 
-  static FloBigQueryClient defaultBigQuerySupplier() {
-    if (FloTesting.isTest()) {
-      return BigQueryMocking.mock().client();
-    } else {
-      return BigQueryClientSingleton.BIGQUERY_CLIENT;
-    }
-  }
 }

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryMocking.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryMocking.java
@@ -20,11 +20,19 @@
 
 package com.spotify.flo.contrib.bigquery;
 
+import com.google.cloud.bigquery.BigQuery.JobOption;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryRequest;
+import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableId;
 import com.spotify.flo.TestContext;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -144,12 +152,56 @@ public class BigQueryMocking {
     }
 
     @Override
+    public JobInfo job(JobInfo jobInfo, JobOption... options) {
+      return jobInfo;
+    }
+
+    @Override
+    public BigQueryResult query(QueryRequest request) {
+      return new MockQueryResult(request);
+    }
+
+    @Override
     public void publish(StagingTableId stagingTableId, TableId tableId) {
       stagingTableIds.remove(formatTableIdKey(tableId));
 
       final DatasetId datasetId = datasetIdOf(tableId);
       publishedTables.computeIfAbsent(datasetId, k -> new ConcurrentSkipListSet<>())
           .add(tableId.getTable());
+    }
+
+    private class MockQueryResult implements BigQueryResult {
+
+      private final QueryRequest request;
+
+      public MockQueryResult(QueryRequest request) {
+        this.request = Objects.requireNonNull(request, "request");
+      }
+
+      @Override
+      public boolean cacheHit() {
+        return false;
+      }
+
+      @Override
+      public Schema schema() {
+        throw new UnsupportedOperationException("TODO");
+      }
+
+      @Override
+      public long totalBytesProcessed() {
+        throw new UnsupportedOperationException("TODO");
+      }
+
+      @Override
+      public long totalRows() {
+        throw new UnsupportedOperationException("TODO");
+      }
+
+      @Override
+      public Iterator<List<FieldValue>> iterator() {
+        throw new UnsupportedOperationException("TODO");
+      }
     }
   }
 }

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryOperation.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryOperation.java
@@ -1,0 +1,108 @@
+/*-
+ * -\-\-
+ * Flo BigQuery
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.bigquery;
+
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryRequest;
+import com.spotify.flo.Fn;
+import com.spotify.flo.TaskBuilder.F1;
+import java.util.Objects;
+
+/**
+ * A BigQuery operation to be executed by the {@link BigQueryOperator}.
+ */
+public class BigQueryOperation<T, R> {
+
+  Fn<JobInfo> jobRequest;
+  Fn<QueryRequest> queryRequest;
+  F1<Object, T> success;
+
+  /**
+   * Run a query. Result are returned directly and not written to a table.
+   */
+  @SuppressWarnings("unchecked")
+  BigQueryOperation<T, BigQueryResult> query(Fn<QueryRequest> queryRequest) {
+    if (jobRequest != null) {
+      throw new IllegalStateException("can only run either a query or a job");
+    }
+    this.queryRequest = Objects.requireNonNull(queryRequest);
+    return (BigQueryOperation<T, BigQueryResult>) this;
+  }
+
+  /**
+   * Run a job. This can be a query, copy, load or extract with results written to a table, etc.
+   */
+  @SuppressWarnings("unchecked")
+  BigQueryOperation<T, JobInfo> job(Fn<JobInfo> jobRequest) {
+    if (queryRequest != null) {
+      throw new IllegalStateException("can only run either a query or a job");
+    }
+    this.jobRequest = Objects.requireNonNull(jobRequest);
+    return (BigQueryOperation<T, JobInfo>) this;
+  }
+
+  /**
+   * Specify some action to take on success. E.g. publishing a staging table.
+   */
+  @SuppressWarnings("unchecked")
+  BigQueryOperation<T, R> success(F1<R, T> success) {
+    this.success = (F1<Object, T>) Objects.requireNonNull(success);
+    return this;
+  }
+
+  static <T> BigQueryOperation<T, BigQueryResult> ofQuery(Fn<QueryRequest> queryRequest) {
+    return new BigQueryOperation<T, BigQueryResult>().query(queryRequest);
+  }
+
+  static <T> BigQueryOperation<T, JobInfo> ofJob(Fn<JobInfo> job) {
+    return new BigQueryOperation<T, JobInfo>().job(job);
+  }
+
+  public static class Provider<T> {
+
+    Provider() {
+    }
+
+    public BigQueryOperation<T, Object> bq() {
+      return new BigQueryOperation<>();
+    }
+
+    public BigQueryOperation<T, BigQueryResult> query(Fn<QueryRequest> queryRequest) {
+      return BigQueryOperation.ofQuery(queryRequest);
+    }
+
+    public BigQueryOperation<T, BigQueryResult> query(QueryRequest queryRequest) {
+      return BigQueryOperation.ofQuery(() -> queryRequest);
+    }
+
+    public BigQueryOperation<T, BigQueryResult> query(String query) {
+      return BigQueryOperation.ofQuery(() -> QueryRequest.of(query));
+    }
+
+    public BigQueryOperation<T, JobInfo> job(Fn<JobInfo> jobInfo) {
+      return BigQueryOperation.ofJob(jobInfo);
+    }
+
+    public BigQueryOperation<T, JobInfo> job(JobInfo jobInfo) {
+      return BigQueryOperation.ofJob(() -> jobInfo);
+    }
+  }
+}

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryOperator.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryOperator.java
@@ -1,0 +1,64 @@
+/*-
+ * -\-\-
+ * Flo BigQuery
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.bigquery;
+
+import static com.spotify.flo.contrib.bigquery.BigQueryClientSingleton.bq;
+
+import com.google.cloud.bigquery.JobInfo;
+import com.spotify.flo.EvalContext;
+import com.spotify.flo.TaskOperator;
+import com.spotify.flo.contrib.bigquery.BigQueryOperation.Provider;
+
+public class BigQueryOperator<T> implements TaskOperator<BigQueryOperation.Provider<T>, BigQueryOperation<T, ?>, T> {
+
+  private BigQueryOperator() {
+  }
+
+  @Override
+  public T perform(BigQueryOperation<T, ?> spec, Listener listener) {
+    final Object result;
+    if (spec.queryRequest != null) {
+      result = runQuery(spec);
+    } else if (spec.jobRequest != null) {
+      result = runJob(spec);
+    } else {
+      throw new AssertionError();
+    }
+    return spec.success.apply(result);
+  }
+
+  private JobInfo runJob(BigQueryOperation<T, ?> spec) {
+    return bq().job(spec.jobRequest.get());
+  }
+
+  private BigQueryResult runQuery(BigQueryOperation<T, ?> spec) {
+    return bq().query(spec.queryRequest.get());
+  }
+
+  public static <T> BigQueryOperator<T> create() {
+    return new BigQueryOperator<>();
+  }
+
+  @Override
+  public Provider<T> provide(EvalContext evalContext) {
+    return new BigQueryOperation.Provider<>();
+  }
+}

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryResult.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryResult.java
@@ -1,0 +1,39 @@
+/*-
+ * -\-\-
+ * Flo BigQuery
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.bigquery;
+
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.Schema;
+import java.util.List;
+
+/**
+ * A mockable {@link com.google.cloud.bigquery.QueryResult}
+ */
+public interface BigQueryResult extends Iterable<List<FieldValue>> {
+
+  boolean cacheHit();
+
+  Schema schema();
+
+  long totalBytesProcessed();
+
+  long totalRows();
+}

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryTasks.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryTasks.java
@@ -48,7 +48,7 @@ public final class BigQueryTasks {
   }
 
   public static Task<TableId> lookup(TableId tableId) {
-    return lookup(BigQueryContext::defaultBigQuerySupplier, tableId);
+    return lookup(BigQueryClientSingleton::bq, tableId);
   }
 
   public static Task<TableId> lookup(String project, String dataset, String table) {

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/FloBigQueryClient.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/FloBigQueryClient.java
@@ -20,8 +20,12 @@
 
 package com.spotify.flo.contrib.bigquery;
 
+import com.google.cloud.bigquery.BigQuery.JobOption;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryRequest;
 import com.google.cloud.bigquery.TableId;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -54,6 +58,20 @@ interface FloBigQueryClient {
    * @return true if it exists, otherwise false
    */
   boolean tableExists(TableId tableId);
+
+  /**
+   * Run a BigQuery query. Blocks until the query completes.
+   *
+   * @throws BigQueryException if the query fails.
+   */
+  BigQueryResult query(QueryRequest queryRequest);
+
+  /**
+   * Run a BiqQuery job. Blocks until the job completes.
+   *
+   * @throws BigQueryException if the job fails.
+   */
+  JobInfo job(JobInfo jobInfo, JobOption... options);
 
   /**
    * Create a staging {@link TableId} for {@param tableId}

--- a/contrib/flo-bigquery/src/test/java/com/spotify/flo/contrib/bigquery/BigQueryOperatorTest.java
+++ b/contrib/flo-bigquery/src/test/java/com/spotify/flo/contrib/bigquery/BigQueryOperatorTest.java
@@ -1,0 +1,77 @@
+/*-
+ * -\-\-
+ * Flo BigQuery
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.contrib.bigquery;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.TableId;
+import com.spotify.flo.FloTesting;
+import com.spotify.flo.Task;
+import com.spotify.flo.TestScope;
+import com.spotify.flo.context.FloRunner;
+import org.junit.Test;
+
+public class BigQueryOperatorTest {
+
+  @Test
+  public void shouldRunQueryTestMode() throws Exception {
+    final Task<String> task = Task.named("task")
+        .ofType(String.class)
+        .operator(BigQueryOperator.create())
+        .process(bq -> bq.query("SELECT foo FROM input")
+            .success(result -> "success!"));
+
+    try (TestScope scope = FloTesting.scope()) {
+      final String result = FloRunner.runTask(task).future()
+          .get(30, SECONDS);
+      assertThat(result, is("success!"));
+    }
+  }
+
+  @Test
+  public void shouldRunQueryJobInTestMode() throws Exception {
+    TableId table = TableId.of("foo", "bar", "baz");
+
+    final Task<TableId> task = Task.named("task")
+        .ofType(TableId.class)
+        .context(BigQueryContext.create(table))
+        .operator(BigQueryOperator.create())
+        .process((stagingTable, bq) -> bq.job(
+            JobInfo.of(QueryJobConfiguration.newBuilder("SELECT foo FROM input")
+                .setDestinationTable(stagingTable.tableId())
+                .build()))
+            .success(response -> stagingTable.publish()));
+
+    try (TestScope scope = FloTesting.scope()) {
+
+      final TableId result = FloRunner.runTask(task).future()
+          .get(30, SECONDS);
+
+      assertThat(result, is(table));
+      assertThat(BigQueryMocking.mock().tablePublished(table), is(true));
+      assertThat(BigQueryMocking.mock().tableExists(table), is(true));
+    }
+  }
+}


### PR DESCRIPTION
Usage:

**Run a query and create table from results**
```java
final Task<TableId> task = Task.named("task")
    .ofType(TableId.class)
    .context(BigQueryContext.create(table))
    .context(BigQueryOperator.create())
    .process((stagingTable, bq) -> bq.job(
        JobInfo.of(QueryJobConfiguration.newBuilder("SELECT foo FROM input")
            .setDestinationTable(stagingTable.tableId())
            .build()))
        .success(response -> stagingTable.publish()));
```

**Run a query and get the results directly**
```java
final Task<String> task = Task.named("task")
    .ofType(String.class)
    .context(BigQueryOperator.create())
    .process(bq -> bq.query("SELECT foo FROM input")
        .success(result -> "success!"));
```

**Load data from GCS (via hades)**
```java
final Task<TableId> task = Task.named("load")
    .ofType(TableId.class)
    .input(() -> HadesTasks.lookup("src-endpoint", "src-partition"))
    .context(BigQueryContext.create(TableId.of("dst-project", "dst-dataset", "dst-table")))
    .operator(BigQueryOperator.create())
    .process((input, table, bq) -> bq
        .job(LoadJobConfiguration
            .newBuilder(table.tableId(), input.uri())
            .setSchema(Schema.of(...))) // configure avro schema?
        .success(job -> table.publish()));
```

