### PR TITLE
fix staging table id generation

### DIFF
--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryContext.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryContext.java
@@ -81,8 +81,8 @@ public class BigQueryContext extends TaskContextStrict<StagingTableId, TableId> 
   public StagingTableId provide(EvalContext evalContext) {
     final String location = getDatasetOrThrow().getLocation();
 
-    final StagingTableId stagingTableId = bigQuery().createStagingTableId(this, tableId);
-    final DatasetId stagingDatasetId = DatasetId.of(stagingTableId.tableId().getProject(), stagingTableId.tableId().getDataset());
+    final TableId stagingTableId = bigQuery().createStagingTableId(tableId, location);
+    final DatasetId stagingDatasetId = DatasetId.of(stagingTableId.getProject(), stagingTableId.getDataset());
 
     if (bigQuery().getDataset(stagingDatasetId) == null) {
       bigQuery().create(DatasetInfo
@@ -93,7 +93,7 @@ public class BigQueryContext extends TaskContextStrict<StagingTableId, TableId> 
       LOG.info("created staging dataset: {}", stagingDatasetId);
     }
 
-    return stagingTableId;
+    return StagingTableId.of(this, stagingTableId);
   }
 
   @Override

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryMocking.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryMocking.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class BigQueryMocking {
 
@@ -53,7 +52,7 @@ public class BigQueryMocking {
   }
 
 
-  public FloBigQueryClient client() {
+  FloBigQueryClient client() {
     return new MockBigQueryClient();
   }
 
@@ -139,19 +138,9 @@ public class BigQueryMocking {
     }
 
     @Override
-    public StagingTableId createStagingTableId(BigQueryContext context, TableId tableId) {
+    public TableId createStagingTableId(TableId tableId, String location) {
       return Optional.ofNullable(stagingTableIds.get(formatTableIdKey(tableId)))
-          //read from mocked stagingTableIds if exists
-          .map(stagingTableId -> StagingTableId.of(context, stagingTableId))
-          //create a new StagingTableId
-          .orElse(StagingTableId.of(
-              context,
-              TableId.of(
-                  tableId.getProject(),
-                  "_incoming_test",
-                  "_" + tableId.getTable() + "_" + ThreadLocalRandom.current().nextLong(10_000_000))
-              )
-          );
+          .orElseGet(() -> FloBigQueryClient.randomStagingTableId(tableId, location));
     }
 
     @Override

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/DefaultBigQueryClient.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/DefaultBigQueryClient.java
@@ -20,6 +20,8 @@
 
 package com.spotify.flo.contrib.bigquery;
 
+import static com.spotify.flo.contrib.bigquery.FloBigQueryClient.randomStagingTableId;
+
 import com.google.cloud.WaitForOption;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
@@ -29,12 +31,13 @@ import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.TableId;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DefaultBigQueryClient implements FloBigQueryClient {
+class DefaultBigQueryClient implements FloBigQueryClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultBigQueryClient.class);
   private final BigQuery client;
@@ -59,11 +62,8 @@ public class DefaultBigQueryClient implements FloBigQueryClient {
   }
 
   @Override
-  public StagingTableId createStagingTableId(BigQueryContext context, TableId tableId) {
-    return StagingTableId.of(
-        context,
-        TableId.of(tableId.getProject(), "_incoming_", tableId.getTable())
-    );
+  public TableId createStagingTableId(TableId tableId, String location) {
+    return randomStagingTableId(tableId, location);
   }
 
   @Override

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/FloBigQueryClient.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/FloBigQueryClient.java
@@ -23,11 +23,12 @@ package com.spotify.flo.contrib.bigquery;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.TableId;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * An interface to BigQuery utilities.
  */
-public interface FloBigQueryClient {
+interface FloBigQueryClient {
 
   /**
    * Get a dataset by Id
@@ -55,7 +56,16 @@ public interface FloBigQueryClient {
   boolean tableExists(TableId tableId);
 
   /**
-   * Create a {@link StagingTableId} for {@param tableId}
+   * Create a staging {@link TableId} for {@param tableId}
    */
-  StagingTableId createStagingTableId(BigQueryContext context, TableId tableId);
+  TableId createStagingTableId(TableId tableId, String location);
+
+  /**
+   * Create a random staging table id.
+   */
+  static TableId randomStagingTableId(TableId tableId, String location) {
+    final DatasetId stagingDatasetId = DatasetId.of(tableId.getProject(), "_incoming_" + location);
+    final String table = "_" + tableId.getTable() + "_" + ThreadLocalRandom.current().nextLong(10_000_000);
+    return TableId.of(stagingDatasetId.getProject(), stagingDatasetId.getDataset(), table);
+  }
 }


### PR DESCRIPTION
Fix bigquery staging broken in #124 

Reverts the behavior of staging dataset and table generation to be equivalent to before #124.