### PR TITLE
[hold] Propagate user.home to subprocess

### DIFF
--- a/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
@@ -111,9 +111,10 @@ class ForkingExecutor implements Closeable {
     private final Path resultFile = tempdir.resolve("result");
     private final Path errorFile = tempdir.resolve("error");
 
-    private final String home = System.getProperty("java.home");
+    private final String userHome = System.getProperty("user.home");
+    private final String javaHome = System.getProperty("java.home");
     private final String classPath = System.getProperty("java.class.path");
-    private final Path java = Paths.get(home, "bin", "java").toAbsolutePath().normalize();
+    private final Path java = Paths.get(javaHome, "bin", "java").toAbsolutePath().normalize();
 
     private final Fn<T> f;
 
@@ -149,6 +150,7 @@ class ForkingExecutor implements Closeable {
       // Custom jvm args
       javaArgs.forEach(processBuilder.command()::add);
 
+      processBuilder.command().add("-Duser.home="+userHome);
       // Trampoline arguments
       processBuilder.command().add(Trampoline.class.getName());
       processBuilder.command().add(closureFile.toString());


### PR DESCRIPTION
When forking, the `BigQuery` client used by `BigQueryContext` looks for the local google cloud project, which is fetched following this priority of locations: https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/google-cloud-clients/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java#L332

The last most alternative is reading from the local `$HOME/.config/gcloud/` and if the preferred home folder location is not propagate properly, the subprocess ends up using the default home folder location https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/google-cloud-clients/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java#L370