### PR TITLE
bq: use SA project id as default

### DIFF
--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryClientSingleton.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryClientSingleton.java
@@ -35,6 +35,7 @@ class BigQueryClientSingleton {
     // Work around a bug in ServiceOptions.getDefaultProjectId() where it will use the project
     // returned by the GCE metadata server instead of the service account project
     // https://github.com/GoogleCloudPlatform/google-cloud-java/pull/2304/files#diff-966eb51fcb59c92eb46ebd5f532d8e52R404
+    // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/3533
     final String serviceAccountProjectId = getServiceAccountProjectId();
     if (serviceAccountProjectId != null) {
       bigquery.setProjectId(serviceAccountProjectId);

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryClientSingleton.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryClientSingleton.java
@@ -20,10 +20,8 @@
 
 package com.spotify.flo.contrib.bigquery;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
-import java.io.IOException;
 
 class BigQueryClientSingleton {
 
@@ -36,19 +34,11 @@ class BigQueryClientSingleton {
     // returned by the GCE metadata server instead of the service account project
     // https://github.com/GoogleCloudPlatform/google-cloud-java/pull/2304/files#diff-966eb51fcb59c92eb46ebd5f532d8e52R404
     // https://github.com/GoogleCloudPlatform/google-cloud-java/issues/3533
-    final String serviceAccountProjectId = getServiceAccountProjectId();
-    if (serviceAccountProjectId != null) {
-      bigquery.setProjectId(serviceAccountProjectId);
+    final String projectId = GcpOptions.getDefaultProjectId();
+    if (projectId != null) {
+      bigquery.setProjectId(projectId);
     }
     BIGQUERY_INTERNAL = bigquery.build().getService();
     BIGQUERY_CLIENT = new DefaultBigQueryClient(BIGQUERY_INTERNAL);
-  }
-
-  private static String getServiceAccountProjectId() {
-    try {
-      return GoogleCredential.getApplicationDefault().getServiceAccountProjectId();
-    } catch (IOException e) {
-      return null;
-    }
   }
 }

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/GcpOptions.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/GcpOptions.java
@@ -1,3 +1,23 @@
+/*-
+ * -\-\-
+ * Flo BigQuery
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
 package com.spotify.flo.contrib.bigquery;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/GcpOptions.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/GcpOptions.java
@@ -1,0 +1,34 @@
+package com.spotify.flo.contrib.bigquery;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.cloud.ServiceOptions;
+import java.io.IOException;
+
+class GcpOptions {
+
+  private static final String LEGACY_PROJECT_ENV_NAME = "GCLOUD_PROJECT";
+  private static final String PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
+
+  /**
+   * A version of {@link ServiceOptions#getDefaultProject()} that defaults to the service account
+   * project instead of the GCE (metadata server) project id.
+   */
+  static String getDefaultProjectId() {
+    String projectId = System.getProperty(PROJECT_ENV_NAME, System.getenv(PROJECT_ENV_NAME));
+    if (projectId == null) {
+      projectId = System.getProperty(LEGACY_PROJECT_ENV_NAME, System.getenv(LEGACY_PROJECT_ENV_NAME));
+    }
+    if (projectId == null) {
+      projectId = getServiceAccountProjectId();
+    }
+    return (projectId != null) ? projectId : ServiceOptions.getDefaultProjectId();
+  }
+
+  private static String getServiceAccountProjectId() {
+    try {
+      return GoogleCredential.getApplicationDefault().getServiceAccountProjectId();
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Work around a bug google-cloud-java bug introduced in https://github.com/GoogleCloudPlatform/google-cloud-java/pull/2304

Also make BigQueryClientSingleton package-private.