### PR TITLE
Scio failure handling

### DIFF
--- a/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioJobSpec.scala
+++ b/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioJobSpec.scala
@@ -28,23 +28,40 @@ class ScioJobSpec[R, S](private[scio] val taskId: TaskId,
                         private[scio] val options: Option[() => PipelineOptions] = None,
                         private[scio] val pipeline: ScioContext => Unit = null,
                         private[scio] val result: (ScioContext, ScioResult) => R = null,
-                        private[scio] val success: R => S = null
+                        private[scio] val success: R => S = null,
+                        private[scio] val failure: Throwable => S = (t: Throwable) => { throw t }
                        ) extends Serializable {
 
   def options(options: () => PipelineOptions): ScioJobSpec[R, S] = {
-    new ScioJobSpec(taskId, Some(options), pipeline, result, success)
+    require(options != null)
+    new ScioJobSpec(taskId, Some(options), pipeline, result, success, failure)
   }
 
   def pipeline(pipeline: ScioContext => Unit): ScioJobSpec[R, S] = {
-    new ScioJobSpec(taskId, options, pipeline, result, success)
+    require(pipeline != null)
+    new ScioJobSpec(taskId, options, pipeline, result, success, failure)
   }
 
   def result[RN <: R](result: (ScioContext, ScioResult) => RN): ScioJobSpec[RN, S] = {
-    new ScioJobSpec(taskId, options, pipeline, result, success)
+    require(result != null)
+    new ScioJobSpec(taskId, options, pipeline, result, success, failure)
   }
 
   def success(success: R => S): ScioJobSpec[R, S] = {
-    new ScioJobSpec(taskId, options, pipeline, result, success)
+    require(success != null)
+    new ScioJobSpec(taskId, options, pipeline, result, success, failure)
+  }
+
+  def failure(failure: Throwable => S): ScioJobSpec[R, S] = {
+    require(failure != null)
+    new ScioJobSpec(taskId, options, pipeline, result, success, failure)
+  }
+
+  private[scio] def validate(): Unit = {
+    require(pipeline != null)
+    require(result != null)
+    require(success != null)
+    require(failure != null)
   }
 }
 

--- a/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioJobSpec.scala
+++ b/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioJobSpec.scala
@@ -58,6 +58,7 @@ class ScioJobSpec[R, S](private[scio] val taskId: TaskId,
   }
 
   private[scio] def validate(): Unit = {
+    require(options != null)
     require(pipeline != null)
     require(result != null)
     require(success != null)

--- a/flo-runner/src/main/java/com/spotify/flo/status/NotRetriable.java
+++ b/flo-runner/src/main/java/com/spotify/flo/status/NotRetriable.java
@@ -24,4 +24,11 @@ package com.spotify.flo.status;
  * Signals that a task has failed and should not be retried.
  */
 public class NotRetriable extends TaskStatusException {
+
+  public NotRetriable() {
+  }
+
+  public NotRetriable(String message) {
+    super(message);
+  }
 }

--- a/flo-runner/src/main/java/com/spotify/flo/status/TaskStatusException.java
+++ b/flo-runner/src/main/java/com/spotify/flo/status/TaskStatusException.java
@@ -24,4 +24,11 @@ package com.spotify.flo.status;
  * Generic exception for signalling that a task could not execute for some reason.
  */
 public abstract class TaskStatusException extends RuntimeException {
+
+  public TaskStatusException() {
+  }
+
+  public TaskStatusException(String message) {
+    super(message);
+  }
 }


### PR DESCRIPTION
Add a method to configure failure handling when using the `ScioOperator`. Example:

```scala
.result((sc, sr) => SomeValidationLibrary.validateCounters(sc, sr)) // throws ValidationError
.success(...)
.failure(t => t match {
  case ValidationError(msg) => throw new NotRetriable(msg) // do not retry on ValidationError
  case _ => throw JobError(t)
})
```

