### PR TITLE
add job type to metadata

### DIFF
--- a/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioOperator.scala
+++ b/contrib/flo-scio_2.12/src/main/scala/com/spotify/flo/contrib/scio/ScioOperator.scala
@@ -150,6 +150,7 @@ class ScioOperator[T] extends TaskOperator[ScioJobSpec.Provider[T], ScioJobSpec[
   private def reportDataflowJob(taskId: TaskId, job: DataflowPipelineJob, listener: TaskOperator.Listener) {
     val url = dataflowJobMonitoringPageURL(job)
     val jobMeta = Map(
+      "job-type" → "dataflow",
       "job-id" -> job.getJobId,
       "project-id" -> job.getProjectId,
       "region" -> job.getRegion,


### PR DESCRIPTION
for the sake of easier usage later.