### PR TITLE
scio: make scio-test dependency optional

### DIFF
--- a/contrib/flo-scio_2.11/pom.xml
+++ b/contrib/flo-scio_2.11/pom.xml
@@ -34,6 +34,7 @@
       <groupId>com.spotify</groupId>
       <artifactId>scio-test_2.11</artifactId>
       <version>0.5.5</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/contrib/flo-scio_2.12/pom.xml
+++ b/contrib/flo-scio_2.12/pom.xml
@@ -34,6 +34,7 @@
       <groupId>com.spotify</groupId>
       <artifactId>scio-test_2.12</artifactId>
       <version>0.5.5</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Make the `scio-test` dependency `optional`.

## Motivation and Context
We do not want to include scio-test and its dependencies (scalatest etc) in user production artifacts.

To use `scala-test`, users must now add an explicit dependency. That seems to already be common practice.

Note that the `ScioOperator` code still contains references to classes in `scio-test`, but only in methods that are used as part of testing, like `ScioOperator.mock()`.

## Have you tested this? If so, how?
Verified that this works both for running a production scio job and local tests using our internal `flo-example`.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
