### PR TITLE
memoization: avoid recursive computeIfAbsent

### DIFF
--- a/flo-workflow/src/main/java/com/spotify/flo/context/MemoizingContext.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/context/MemoizingContext.java
@@ -46,10 +46,8 @@ public class MemoizingContext extends ForwardingEvalContext {
   @Override
   public <T> Value<T> evaluateInternal(Task<T> task, EvalContext context) {
     // Unfortunately we cannot use computeIfAbsent here because modification of the CHM
-    // in computeIfAbsents is not allowed: "... the computation should be short and simple,
+    // in computeIfAbsent is not allowed: "... the computation should be short and simple,
     // and must not attempt to update any other mappings of this map.".
-    // However, we could potentially use computeIfAbsent if we rewrite flo task evaluation
-    // to be iterative instead of recursive.
     final Promise<T> promise = context.promise();
     final Promise<?> existing = ongoing.putIfAbsent(task.id(), promise);
     if (existing != null) {

--- a/flo-workflow/src/main/java/com/spotify/flo/context/MemoizingContext.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/context/MemoizingContext.java
@@ -50,18 +50,18 @@ public class MemoizingContext extends ForwardingEvalContext {
     // and must not attempt to update any other mappings of this map.".
     // However, we could potentially use computeIfAbsent if we rewrite flo task evaluation
     // to be iterative instead of recursive.
-    final Promise<T> f = context.promise();
-    final Promise<?> existing = ongoing.putIfAbsent(task.id(), f);
+    final Promise<T> promise = context.promise();
+    final Promise<?> existing = ongoing.putIfAbsent(task.id(), promise);
     if (existing != null) {
       return (Value<T>) existing.value();
     }
     try {
       final Value<T> value = super.evaluateInternal(task, context);
-      value.onFail(f::fail);
-      value.consume(f::set);
+      value.onFail(promise::fail);
+      value.consume(promise::set);
     } catch (Throwable t) {
-      f.fail(t);
+      promise.fail(t);
     }
-    return f.value();
+    return promise.value();
   }
 }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Avoid recursive `CHM.computeIfAbsent`.

## Motivation and Context
https://bugs.openjdk.java.net/browse/JDK-8062841

## Have you tested this? If so, how?
Tests pass.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
