### PR TITLE
remove flo.forking and FLO_FORKING flags

### DIFF
--- a/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
+++ b/contrib/flo-styx/src/test/java/com/spotify/flo/contrib/styx/StructuredLoggingTest.java
@@ -83,17 +83,13 @@ public class StructuredLoggingTest {
     }
   }
 
-  @Parameters({"true", "false"})
   @Test
-  public void testStructuredLoggingProgrammaticSetup(boolean forking) throws Exception {
-    configureForking(forking);
+  public void testStructuredLoggingProgrammaticSetup() throws Exception {
     verifyStructuredLogging(() -> StructuredLogging.configureStructuredLogging(Level.DEBUG));
   }
 
-  @Parameters({"true", "false"})
   @Test
-  public void testStructuredLoggingFileSetup(boolean forking) throws Exception {
-    configureForking(forking);
+  public void testStructuredLoggingFileSetup() throws Exception {
     verifyStructuredLogging(this::configureLogbackFromFile);
   }
 
@@ -168,18 +164,14 @@ public class StructuredLoggingTest {
     }
   }
 
-  @Parameters({"true", "false"})
   @Test
-  public void testTextLoggingProgrammaticSetup(boolean forking) throws Exception {
-    configureForking(forking);
+  public void testTextLoggingProgrammaticSetup() throws Exception {
     StructuredLogging.configureStructuredLogging();
     verifyTextLogging();
   }
 
-  @Parameters({"true", "false"})
   @Test
-  public void testTextLoggingFileSetup(boolean forking) throws Exception {
-    configureForking(forking);
+  public void testTextLoggingFileSetup() throws Exception {
     configureLogbackFromFile();
     verifyTextLogging();
   }
@@ -270,9 +262,5 @@ public class StructuredLoggingTest {
     exception.addSuppressed(new RuntimeException("suppressed1", new IllegalStateException("inner suppressed1")));
     exception.addSuppressed(new RuntimeException("suppressed2", new IllegalStateException("inner suppressed2")));
     return exception;
-  }
-
-  private void configureForking(boolean forking) {
-    env.set("FLO_FORKING", Boolean.toString(forking));
   }
 }

--- a/flo-runner/README.md
+++ b/flo-runner/README.md
@@ -76,7 +76,6 @@ running the jar (`java -Dproperty=value <jar>`).
 
 | property | behaviour |
 |:---:|---|
-| **`-Dflo.forking=true`** | Fork a subprocess for each task. |
 | **`-Dflo.workers=n`** | Use `n` workers for running tasks concurrently. |
 | **`-Dmode=tree`** | Only print the Evaluation plan and exit. |
 

--- a/flo-runner/src/main/java/com/spotify/flo/context/FloRunner.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/FloRunner.java
@@ -74,7 +74,6 @@ public final class FloRunner<T> {
   private static final String MODE = "mode";
   private static final String FLO_ASYNC = "flo.async";
   private static final String FLO_WORKERS = "flo.workers";
-  private static final String FLO_FORKING = "flo.forking";
   private static final String FLO_STATE_LOCATION = "flo.state.location";
 
   private final Logging logging = Logging.create(LOG);
@@ -224,21 +223,10 @@ public final class FloRunner<T> {
     final boolean inDebugger = ManagementFactory.getRuntimeMXBean()
         .getInputArguments().stream().anyMatch(s -> s.contains("-agentlib:jdwp"));
 
-    if (hasExplicitConfigValue(FLO_FORKING)) {
-      if (config.getBoolean(FLO_FORKING)) {
-        LOG.debug("Forking enabled (config variable flo.forking=true)");
-        return ForkingContext.composeWith(baseContext);
-      } else {
-        LOG.debug("Forking disabled (config variable flo.forking=false)");
-        return baseContext;
-      }
-    } else if (inDebugger) {
-      LOG.debug("Debugger detected, dry-running forking "
-          + "(enable full forking by setting config variable flo.forking=true)");
+    if (inDebugger) {
+      LOG.debug("Debugger detected, dry-running forking");
       return ForkingContext.dryComposeWith(baseContext);
     } else {
-      LOG.debug("Debugger not detected, forking enabled by default "
-          + "(disable by setting config variable flo.forking=false)");
       return ForkingContext.composeWith(baseContext);
     }
   }

--- a/flo-runner/src/main/java/com/spotify/flo/context/ForkingContext.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/ForkingContext.java
@@ -56,9 +56,6 @@ class ForkingContext extends ForwardingEvalContext {
 
   @Override
   public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<T> processFn) {
-    if (delegate == null) {
-      throw new UnsupportedOperationException("nested execution not supported");
-    }
     // Wrap the process fn in a lambda that will execute the original process fn closure in a sub-process.
     final Fn<T> forkingProcessFn = fork(taskId, processFn);
     // Pass on the wrapped process fn to let the rest of EvalContexts do their thing. The last EvalContext in the chain
@@ -78,7 +75,7 @@ class ForkingContext extends ForwardingEvalContext {
     }
   }
 
-  private <T> Fn<T> testFork(Fn<T> fn) {
+  private static <T> Fn<T> testFork(Fn<T> fn) {
     // We do not currently have a mechanism for transporting mock inputs and outputs into and out of the task process.
     LOG.debug("Test run, forking disabled - testing serialization");
     return () -> {
@@ -101,7 +98,7 @@ class ForkingContext extends ForwardingEvalContext {
     };
   }
 
-  private <T> Fn<T> realFork(TaskId taskId, Fn<T> fn) {
+  private static <T> Fn<T> realFork(TaskId taskId, Fn<T> fn) {
     return () -> {
       try (final ForkingExecutor executor = new ForkingExecutor()) {
         executor.environment(Collections.singletonMap("FLO_TASK_ID", taskId.toString()));

--- a/flo-runner/src/main/resources/reference.conf
+++ b/flo-runner/src/main/resources/reference.conf
@@ -1,9 +1,6 @@
 flo.workers = 4
 flo.async = true
 
-flo.forking = true
-flo.forking = ${?FLO_FORKING}
-
 # these are intended to be set through env vars with the FLO_ prefix, so no namespace
 mode = "default" # {tree,persist}
 jsonTree = false


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
remove `flo.forking` and `FLO_FORKING` flags

## Motivation and Context
The `flo.forking` flag has become a crutch that is being used to work around and prolong the pain of serialization issues in both flo and user code.

It is also confusing to users who believe that `flo.forking` is a flag that they _should_ be using and are annoyed that it is hard to find and causes their code to behave differently.

Instead, let's fix and document the serialization issues that users are encountering.

## Have you tested this? If so, how?
Tests pass.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
