### PR TITLE
use jackson for @JsonSerialize annotated types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             JAVA: java -Xmx512m -Xms512m
             # Maven heap size
             MAVEN_OPTS: -Xmx256m -Xms256m
-          command: mvn -B verify scala:doc-jar -Pcoverage
+          command: mvn -B verify -Pcoverage,release -Dgpg.skip=true
       - run: bash <(curl -s https://codecov.io/bash)
 
   test_jdk10:
@@ -35,7 +35,7 @@ jobs:
           key: v1-deps-jdk10-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
-      - run: mvn -B verify scala:doc-jar
+      - run: mvn -B verify -Prelease -Dgpg.skip=true
 
 workflows:
   version: 2

--- a/flo-freezer/pom.xml
+++ b/flo-freezer/pom.xml
@@ -30,5 +30,22 @@
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill_2.11</artifactId>
+      <version>0.9.2</version>
+      <optional>true</optional>
+    </dependency>
+
+    <!--test deps-->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-direct-java</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/JacksonJsonSerializer.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/JacksonJsonSerializer.java
@@ -76,6 +76,10 @@ class JacksonJsonSerializer extends Serializer {
     if (type.getAnnotation(JsonSerialize.class) != null) {
       return true;
     }
+    final Class superclass = type.getSuperclass();
+    if (superclass != null && hasJsonSerializeAnnotation(superclass)) {
+      return true;
+    }
     for (Class iface : type.getInterfaces()) {
       if (hasJsonSerializeAnnotation(iface)) {
         return true;

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/JacksonJsonSerializer.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/JacksonJsonSerializer.java
@@ -1,3 +1,23 @@
+/*-
+ * -\-\-
+ * Flo Freezer
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
 package com.spotify.flo.freezer;
 
 import com.esotericsoftware.kryo.Kryo;

--- a/flo-freezer/src/main/java/com/spotify/flo/freezer/JacksonJsonSerializer.java
+++ b/flo-freezer/src/main/java/com/spotify/flo/freezer/JacksonJsonSerializer.java
@@ -1,0 +1,73 @@
+package com.spotify.flo.freezer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Registration;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.JavaSerializer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * A {@link Kryo} {@link Serializer} that serializes types marked with {@link JsonSerialize} as json using Jackson.
+ */
+class JacksonJsonSerializer extends Serializer {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  static Optional<Registration> getRegistration(Kryo kryo, Class type) {
+    return hasJsonSerializeAnnotation(type)
+        ? Optional.of(kryo.getRegistration(RegistrationMarker.class))
+        : Optional.empty();
+  }
+
+  static void register(Kryo kryo) {
+    kryo.register(RegistrationMarker.class, new JacksonJsonSerializer());
+  }
+
+  @Override
+  public void write(Kryo kryo, Output output, Object object) {
+    kryo.writeObject(output, object.getClass(), new JavaSerializer());
+    final byte[] json;
+    try {
+      json = MAPPER.writeValueAsBytes(object);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+    kryo.writeObject(output, json);
+  }
+
+  @Override
+  public Object read(Kryo kryo, Input input, Class type) {
+    final Class<?> klass = kryo.readObject(input, Class.class, new JavaSerializer());
+    final byte[] json = kryo.readObject(input, byte[].class);
+    try {
+      return MAPPER.readValue(json, klass);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static boolean hasJsonSerializeAnnotation(Class type) {
+    if (type.getAnnotation(JsonSerialize.class) != null) {
+      return true;
+    }
+    for (Class iface : type.getInterfaces()) {
+      if (hasJsonSerializeAnnotation(iface)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static final class RegistrationMarker {
+
+    private RegistrationMarker() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/flo-scala_2.11/pom.xml
+++ b/flo-scala_2.11/pom.xml
@@ -50,6 +50,11 @@
       <version>3.0.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-direct-java</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/flo-scala_2.12/pom.xml
+++ b/flo-scala_2.12/pom.xml
@@ -50,6 +50,11 @@
       <version>3.0.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-direct-java</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
use jackson serializaion for @JsonSerialize annotated types

## Motivation and Context
Some types (e.g. beam `PipelineOptions`) are not kryo nor java
serializable, but they are jackson serializable.

## Have you tested this? If so, how?
Added a test for `PipelineOptions`.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
