### PR TITLE
task builder: require java serializability

### DIFF
--- a/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
@@ -13,6 +13,7 @@ import static com.spotify.flo.BuilderUtils.inputArg;
 import static com.spotify.flo.BuilderUtils.inputsArg;
 import static com.spotify.flo.BuilderUtils.lazyFlatten;
 import static com.spotify.flo.BuilderUtils.lazyList;
+import static com.spotify.flo.BuilderUtils.requireSerializable;
 import static com.spotify.flo.Values.toValueList;
 
 /**
@@ -37,22 +38,26 @@ final class {{implClassName}} {
 
     @Override
     public Task<Z> process(F0<Z> f) {
+      requireSerializable(f, "process fn");
       final Invokable code = a -> f.get();
       return Task.create(inputs, taskContexts, type, taskId, code, args);
     }
 
     @Override
     public <A> TaskBuilder1<A, Z, Z> context(TaskContextGeneric<A> context) {
+      requireSerializable(context, "context");
       return context_(context);
     }
 
     @Override
     public <A> TaskBuilder1<A, Z, Z> output(TaskOutput<A, Z> output) {
+      requireSerializable(output, "output");
       return context_(output);
     }
 
     @Override
     public <A, Y> TaskBuilder1<A, Y, Z> operator(TaskOperator<A, Y, Z> operator) {
+      requireSerializable(operator, "operator");
       return context_(operator);
     }
 
@@ -64,6 +69,7 @@ final class {{implClassName}} {
 
     @Override
     public <A> {{interfaceName}}1<A, Z, Z> input(Fn<Task<A>> aTask) {
+      requireSerializable(aTask, "input");
       final Fn<Task<A>> aTaskSingleton = Singleton.create(aTask);
       return new Builder1<>(
           lazyFlatten(inputs, lazyList(aTaskSingleton)),
@@ -72,6 +78,7 @@ final class {{implClassName}} {
 
     @Override
     public <A> {{interfaceName}}1<List<A>, Z, Z> inputs(Fn<List<Task<A>>> aTasks) {
+      requireSerializable(aTasks, "inputs");
       Fn<List<Task<A>>> aTasksSingleton = Singleton.create(aTasks);
       return new Builder1<>(
           lazyFlatten(inputs, lazyFlatten(aTasksSingleton)),
@@ -99,6 +106,7 @@ final class {{implClassName}} {
 
     @Override
     public Task<Z> process(F{{arity}}<{{typeArgs}}, Y> f) {
+      requireSerializable(f, "process fn");
       @SuppressWarnings("unchecked")
       final Invokable code = a -> f.apply({{processArgs}});
       return Task.create(inputs, taskContexts, type, taskId, code, args);
@@ -106,16 +114,19 @@ final class {{implClassName}} {
 
     @Override
     public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Y, Z> context(TaskContextGeneric<{{nextArg}}> context) {
+      requireSerializable(context, "context");
       return context_(context);
     }
 
     @Override
     public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Y, Z> output(TaskOutput<{{nextArg}}, Z> output) {
+      requireSerializable(output, "output");
       return context_(output);
     }
 
     @Override
     public <{{nextArg}}, YN> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, YN, Z> operator(TaskOperator<{{nextArg}}, YN, Z> operator) {
+      requireSerializable(operator, "operator");
       return context_(operator);
     }
 
@@ -127,6 +138,7 @@ final class {{implClassName}} {
 
     @Override
     public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, {{nextArg}}, Y, Z> input(Fn<Task<{{nextArg}}>> nextTask) {
+      requireSerializable(nextTask, "input");
       Fn<Task<{{nextArg}}>> nextTaskSingleton = Singleton.create(nextTask);
       return new Builder{{arityPlus}}<>(
           lazyFlatten(inputs, lazyList(nextTaskSingleton)),
@@ -136,6 +148,7 @@ final class {{implClassName}} {
 
     @Override
     public <{{nextArg}}> {{interfaceName}}{{arityPlus}}<{{typeArgs}}, List<{{nextArg}}>, Y, Z> inputs(Fn<List<Task<{{nextArg}}>>> nextTasks) {
+      requireSerializable(nextTasks, "inputs");
       Fn<List<Task<{{nextArg}}>>> nextTasksSingleton = Singleton.create(nextTasks);
       return new Builder{{arityPlus}}<>(
           lazyFlatten(inputs, lazyFlatten(nextTasksSingleton)),

--- a/flo-workflow/src/main/java/com/spotify/flo/BuilderUtils.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/BuilderUtils.java
@@ -23,11 +23,12 @@ package com.spotify.flo;
 import static com.spotify.flo.Values.toValueList;
 import static java.util.stream.Collectors.toList;
 
-import com.spotify.flo.EvalContext.Value;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +93,23 @@ class BuilderUtils {
       call.run();
     } catch (Throwable t) {
       log.warn("Exception", t);
+    }
+  }
+
+  static <T> T requireSerializable(T o, String name) {
+    try (ObjectOutputStream oos = new ObjectOutputStream(new NullOutputStream())) {
+      oos.writeObject(o);
+      return o;
+    } catch (IOException e) {
+      throw new IllegalArgumentException(name + " not serializable: " + o, e);
+    }
+  }
+
+  private static class NullOutputStream extends OutputStream {
+
+    @Override
+    public void write(int b) {
+      // nop
     }
   }
 }

--- a/flo-workflow/src/main/java/com/spotify/flo/Task.java
+++ b/flo-workflow/src/main/java/com/spotify/flo/Task.java
@@ -83,7 +83,8 @@ public abstract class Task<T> implements Serializable {
     if (contexts.stream().filter(c -> c instanceof TaskOperator).count() > 1) {
       throw new IllegalArgumentException("A task can have at most one TaskOperator");
     }
-    return new AutoValue_Task<>(taskId, type, inputs, contexts, processFn, args);
+    final AutoValue_Task<T> task = new AutoValue_Task<>(taskId, type, inputs, contexts, processFn, args);
+    return BuilderUtils.requireSerializable(task, "task");
   }
 
   /**


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Require java serializability at task build time.

Continuation of https://github.com/spotify/flo/pull/178

## Motivation and Context
Fail early to ease users serialization debugging.

## Have you tested this? If so, how?
Added tests.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
