### PR TITLE
depends on json explicitly

### DIFF
--- a/contrib/flo-bigquery/pom.xml
+++ b/contrib/flo-bigquery/pom.xml
@@ -28,6 +28,10 @@
       <artifactId>google-cloud-bigquery</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
         <version>0.15.0</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>20160810</version>
+      </dependency>
 
       <!-- test dependencies -->
       <dependency>


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Not relying on transitive dependency if we import the classes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Later version of `google-cloud-bigquery` doesn't depend on `json` and that breaks the code.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or -->
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [ ] All tests pass
- [x] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] This PR has been incorporated in release note for the coming version
- [x] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
