### PR TITLE
avoid debian openjdk - bug #911925

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test_jdk8_with_coverage:
     working_directory: ~/flo
     docker:
-      - image: maven:3.5.4-jdk-8
+      - image: maven:3.6.0-jdk-8-alpine
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Use alpine instead of buggy debian openjdk 8.

## Motivation and Context
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or -->
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
