### PR TITLE
Add lookupLatestDaily method to BigQueryTasks

### DIFF
--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryTasks.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryTasks.java
@@ -26,6 +26,7 @@ import com.spotify.flo.Task;
 import com.spotify.flo.TaskBuilder.F0;
 import com.spotify.flo.util.Date;
 import com.spotify.flo.util.DateHour;
+import java.util.Objects;
 
 public final class BigQueryTasks {
 
@@ -47,6 +48,23 @@ public final class BigQueryTasks {
 
   public static Task<TableId> lookup(String project, String dataset, String table) {
     return lookup(TableId.of(project, dataset, table));
+  }
+
+  @VisibleForTesting
+  static Task<TableId> lookupLatestDaily(F0<FloBigQueryClient> bigQuerySupplier, String project, String dataset, String tableName, Date start, final int lookBackDays) {
+    Objects.requireNonNull(project, "project");
+    Objects.requireNonNull(dataset, "dataset");
+    Objects.requireNonNull(tableName, "tableName");
+    Objects.requireNonNull(start, "start");
+
+    return Task.named("bigquery.lookupLatestDaily", project, dataset, tableName, start, lookBackDays)
+        .ofType(TableId.class)
+        .operator(BigQueryLookupOperator.of(bigQuerySupplier))
+        .process(bq -> bq.lookupLatestDaily(project, dataset, tableName, start, lookBackDays));
+  }
+
+  public static Task<TableId> lookupLatestDaily(String project, String dataset, String tableName, Date start, final int lookBackDays) {
+    return lookupLatestDaily(BigQueryClientSingleton::bq, project, dataset, tableName, start, lookBackDays);
   }
 
   public static String formatTableDate(Date date) {

--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryTasks.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryTasks.java
@@ -24,7 +24,6 @@ import com.google.cloud.bigquery.TableId;
 import com.google.common.annotations.VisibleForTesting;
 import com.spotify.flo.Task;
 import com.spotify.flo.TaskBuilder.F0;
-import com.spotify.flo.status.NotReady;
 import com.spotify.flo.util.Date;
 import com.spotify.flo.util.DateHour;
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description

This PR adds a lookupLatestDaily method to BigQueryTasks for looking up a date-partitioned (by table name) BigQuery table starting from a given date with a look-back day limit.

## Motivation and Context

Motivated by actual need. Use case is a pipeline that depends on a date-partitioned table but has a certain bound of late data tolerance and so should proceed with an older table rather than fail on the absence of a table for a single static date.

## Have you tested this? If so, how?

I have included unit tests. I also ran a simple task using lookupLatestDaily via FloRunner and tested correct behavior for table presence/absence.

## Checklist for PR author(s)

- [x] Changes are covered by unit test
- [x] All tests pass
- [x] Code coverage check passes
- [x] Error handling is tested
- [x] Errors are handled at the appropriate layer
- [x] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated (there were no existing docs around this so left as-is)
- [x] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->