### PR TITLE
Add `Flo` in front of `Runner`

### DIFF
--- a/flo-runner/src/main/java/com/spotify/flo/context/Logging.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/Logging.java
@@ -50,7 +50,7 @@ class Logging {
   }
 
   void header() {
-    LOG.info("Runner v{}", getClass().getPackage().getImplementationVersion());
+    LOG.info("FloRunner v{}", getClass().getPackage().getImplementationVersion());
     LOG.info("");
   }
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Add `Flo` in front of `Runner` when logging the flo startup message

## Motivation and Context
Make it easier to grep for and detect flo in logs. 

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or -->
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
