### PR TITLE
Shading tolerant version reading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
             # Maven heap size
             MAVEN_OPTS: -Xmx1024m -Xms1024m
           command: mvn -B verify scala:doc-jar -Pcoverage -Pmissinglink
+      - run: flo-tests/run_shading_tests.sh
       - run: bash <(curl -s https://codecov.io/bash)
 
   test_jdk10:

--- a/flo-runner/pom.xml
+++ b/flo-runner/pom.xml
@@ -42,4 +42,25 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <nonFilteredFileExtensions>
+            <nonFilteredFileExtension>conf</nonFilteredFileExtension>
+          </nonFilteredFileExtensions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/flo-runner/src/main/java/com/spotify/flo/context/Logging.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/Logging.java
@@ -50,7 +50,7 @@ class Logging {
   }
 
   void header() {
-    LOG.info("FloRunner v{}", getClass().getPackage().getImplementationVersion());
+    LOG.info("FloRunner v{}", Version.floRunnerVersion());
     LOG.info("");
   }
 

--- a/flo-runner/src/main/java/com/spotify/flo/context/Version.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/Version.java
@@ -1,0 +1,48 @@
+/*-
+ * -\-\-
+ * Flo Runner
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.context;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+class Version {
+
+  private static final String VERSION_RESOURCE = "/com/spotify/flo/flo-runner.version";
+
+  private static class Lazy {
+
+    private static String RUNNER_VERSION = readFloRunnerVersion();
+  }
+
+  static synchronized String floRunnerVersion() {
+    return Lazy.RUNNER_VERSION;
+  }
+
+  private static String readFloRunnerVersion() {
+    try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
+        Version.class.getResourceAsStream(VERSION_RESOURCE)))) {
+      return reader.readLine().trim();
+    } catch (IOException e) {
+      throw new RuntimeException(String.format("Failed to read flo runner version from %s", VERSION_RESOURCE), e);
+    }
+  }
+}

--- a/flo-runner/src/main/resources/com/spotify/flo/flo-runner.version
+++ b/flo-runner/src/main/resources/com/spotify/flo/flo-runner.version
@@ -1,0 +1,1 @@
+${project.version}

--- a/flo-runner/src/test/java/com/spotify/flo/context/VersionTest.java
+++ b/flo-runner/src/test/java/com/spotify/flo/context/VersionTest.java
@@ -1,0 +1,42 @@
+/*-
+ * -\-\-
+ * Flo Runner
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.flo.context;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import org.junit.Test;
+
+public class VersionTest {
+
+  @Test
+  public void shouldReadFloVersion() throws IOException {
+    final String expectedVersion;
+    try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
+        Version.class.getResourceAsStream("/com/spotify/flo/flo-runner.version")))) {
+      expectedVersion = reader.readLine().trim();
+    }
+    assertThat(Version.floRunnerVersion(), is(expectedVersion));
+  }
+}

--- a/flo-tests/run_shading_tests.sh
+++ b/flo-tests/run_shading_tests.sh
@@ -10,5 +10,5 @@ mvn -B clean install -DskipTests -Dflo.version=$FLO_VERSION
 popd
 
 pushd shading-user
-mvn -B clean test -Dflo.version=$FLO_VERSION
+mvn -B clean test
 popd

--- a/flo-tests/run_shading_tests.sh
+++ b/flo-tests/run_shading_tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")/.."
+FLO_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+mvn -B install -DskipTests
+cd flo-tests
+
+pushd shading
+mvn -B clean install -DskipTests -Dflo.version=$FLO_VERSION
+popd
+
+pushd shading-user
+mvn -B clean test -Dflo.version=$FLO_VERSION
+popd

--- a/flo-tests/shading-user/pom.xml
+++ b/flo-tests/shading-user/pom.xml
@@ -10,7 +10,7 @@
 
   <name>Flo Tests - Shading User</name>
   <artifactId>flo-tests-shading-user</artifactId>
-  <version>${flo.version}</version>
+  <version>0.0.1-SNAPSHOT</version>
   <description>
     Tests using shaded flo
   </description>

--- a/flo-tests/shading-user/pom.xml
+++ b/flo-tests/shading-user/pom.xml
@@ -29,4 +29,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.21.0</version>
+        <configuration>
+          <!-- TODO: remove -Djdk.net.URLClassPath.disableClassPathURLCheck=true after debian fixes
+                     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925 -->
+          <argLine>-Xmx256m -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/flo-tests/shading-user/pom.xml
+++ b/flo-tests/shading-user/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>flo-tests-shading</artifactId>
-      <version>${flo.version}</version>
+      <version>0.0.1-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/flo-tests/shading-user/pom.xml
+++ b/flo-tests/shading-user/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify</groupId>
+    <artifactId>foss-root</artifactId>
+    <version>8</version>
+  </parent>
+
+  <name>Flo Tests - Shading User</name>
+  <artifactId>flo-tests-shading-user</artifactId>
+  <version>${flo.version}</version>
+  <description>
+    Tests using shaded flo
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>flo-tests-shading</artifactId>
+      <version>${flo.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/flo-tests/shading-user/src/test/java/shaded/com/spotify/flo/context/VersionTest.java
+++ b/flo-tests/shading-user/src/test/java/shaded/com/spotify/flo/context/VersionTest.java
@@ -1,0 +1,41 @@
+/*-
+ * -\-\-
+ * Flo Tests - Shading User
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package shaded.com.spotify.flo.context;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import org.junit.Test;
+
+public class VersionTest {
+
+  @Test
+  public void shouldReadRelocatedFloVersion() throws IOException {
+    final String expectedVersion;
+    try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
+        Version.class.getResourceAsStream("/shaded/com/spotify/flo/flo-runner.version")))) {
+      expectedVersion = reader.readLine().trim();
+    }
+    assertEquals(expectedVersion, Version.floRunnerVersion());
+  }
+}

--- a/flo-tests/shading/pom.xml
+++ b/flo-tests/shading/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify</groupId>
+    <artifactId>foss-root</artifactId>
+    <version>8</version>
+  </parent>
+
+  <name>Flo Tests - Shading</name>
+  <artifactId>flo-tests-shading</artifactId>
+  <version>${flo.version}</version>
+  <description>
+    Shaded Flo for testing
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>flo-runner</artifactId>
+      <version>${flo.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Main-Class>com.spotify.flo.context.FloRunner</Main-Class>
+                  </manifestEntries>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>reference.conf</resource>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>com.spotify.flo</pattern>
+                  <shadedPattern>shaded.com.spotify.flo</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/flo-tests/shading/pom.xml
+++ b/flo-tests/shading/pom.xml
@@ -10,7 +10,7 @@
 
   <name>Flo Tests - Shading</name>
   <artifactId>flo-tests-shading</artifactId>
-  <version>${flo.version}</version>
+  <version>0.0.1-SNAPSHOT</version>
   <description>
     Shaded Flo for testing
   </description>


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Shading tolerant version reading

## Motivation and Context
If users (e.g. MC) shades flo-runner, we currently log an incorrect flo runner version.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or -->
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
