### PR TITLE
Use absolute classpath as input

### DIFF
--- a/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
@@ -135,9 +135,14 @@ class ForkingExecutor implements Closeable {
       } catch (SerializationException e) {
         throw new RuntimeException("Failed to serialize closure", e);
       }
+      
+      final String absoluteClassPath =
+          Arrays.stream(classPath.split(File.pathSeparator))
+              .map(cp -> Paths.get(cp).toAbsolutePath().toString())
+              .collect(Collectors.joining(File.pathSeparator));
 
-      final ProcessBuilder processBuilder = new ProcessBuilder(java.toString(), "-cp", classPath)
-          .directory(workdir.toFile());
+      final ProcessBuilder processBuilder =
+          new ProcessBuilder(java.toString(), "-cp", absoluteClassPath).directory(workdir.toFile());
 
       // Propagate -Xmx and -D.
       // Note: This is suboptimal because if the user has configured a max heap size we will effectively use that

--- a/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
@@ -21,7 +21,8 @@
 package com.spotify.flo.context;
 
 import com.spotify.flo.Fn;
-import com.spotify.flo.freezer.PersistingContext;
+import com.spotify.flo.Serialization;
+import com.spotify.flo.SerializationException;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;

--- a/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
+++ b/flo-runner/src/main/java/com/spotify/flo/context/ForkingExecutor.java
@@ -21,11 +21,10 @@
 package com.spotify.flo.context;
 
 import com.spotify.flo.Fn;
-import com.spotify.flo.Serialization;
-import com.spotify.flo.SerializationException;
 import com.spotify.flo.freezer.PersistingContext;
 import java.io.BufferedReader;
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -48,6 +47,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
# Hey I just made a pull request
## Description
When updating to this version of Flo, our jobs failed to execute as it was unable to find the ForkingExecutor class. This was due to the arguments passed in to the classPath variable were not absolute Paths.

## Motivation and Context
When updating to this version of Flow, our jobs failed to execute as it was unable to find the ForkingExecutor class. This was due to the arguments passed in to the classPath variable were not absolute Paths.

## Have you tested this? If so, how?
We have tested this by running it locally, its not possible to unit test as the class path is determined by the environment.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
