### PR TITLE
Bump jackson databinding to 2.9.10.1 + make enforcer happy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,8 @@
 
   <properties>
     <grpc.version>1.13.1</grpc.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.10</jackson.version>
+    <jackson.databind.version>${jackson.version}.1</jackson.databind.version>
     <google.client.version>1.27.0</google.client.version>
     <google.auth.version>0.9.1</google.auth.version>
   </properties>
@@ -104,7 +105,7 @@
       <dependency>
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value</artifactId>
-        <version>1.4</version>
+        <version>1.5.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -144,13 +145,13 @@
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
-        <version>0.24</version>
+        <version>0.44</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.google.testing.compile</groupId>
         <artifactId>compile-testing</artifactId>
-        <version>0.6</version>
+        <version>0.18</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -217,7 +218,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>27.0-jre</version>
+        <version>27.1-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
@@ -242,7 +243,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -377,7 +378,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson.databind.version}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Bump jackson databinding to 2.9.10.1 plus a few more to make maven enforcer happy

## Motivation and Context
Close several security vulnerabilities:
* CVE-2019-16942 moderate severity
* CVE-2019-14540 critical severity
* CVE-2019-16335 critical severity
* CVE-2019-12384 low severity
* CVE-2019-14379 critical severity
* CVE-2019-14439 high severity
* CVE-2019-12814 moderate severity
* CVE-2019-12086 moderate severity

## Have you tested this? If so, how?
I relay on existing test suit to detect any breaking change

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
