### PR TITLE
Bump libraries to use scio 0.7.4

### DIFF
--- a/contrib/flo-scio_2.11/pom.xml
+++ b/contrib/flo-scio_2.11/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.baseVersion}</artifactId>
-      <version>3.0.5</version>
+      <version>3.0.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/contrib/flo-scio_2.11/pom.xml
+++ b/contrib/flo-scio_2.11/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <scala.baseVersion>2.11</scala.baseVersion>
     <scala.version>2.11.12</scala.version>
-    <scio.version>0.6.1</scio.version>
+    <scio.version>0.7.4</scio.version>
   </properties>
 
   <dependencies>

--- a/contrib/flo-scio_2.12/pom.xml
+++ b/contrib/flo-scio_2.12/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <scala.baseVersion>2.12</scala.baseVersion>
     <scala.version>2.12.6</scala.version>
-    <scio.version>0.6.1</scio.version>
+    <scio.version>0.7.4</scio.version>
   </properties>
 
   <dependencies>

--- a/contrib/flo-scio_2.12/pom.xml
+++ b/contrib/flo-scio_2.12/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <scala.baseVersion>2.12</scala.baseVersion>
-    <scala.version>2.12.6</scala.version>
+    <scala.version>2.12.8</scala.version>
     <scio.version>0.7.4</scio.version>
   </properties>
 

--- a/contrib/flo-scio_2.12/pom.xml
+++ b/contrib/flo-scio_2.12/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.baseVersion}</artifactId>
-      <version>3.0.5</version>
+      <version>3.0.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/flo-scala_2.11/pom.xml
+++ b/flo-scala_2.11/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.baseVersion}</artifactId>
-      <version>3.0.5</version>
+      <version>3.0.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/flo-scala_2.12/pom.xml
+++ b/flo-scala_2.12/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <scala.baseVersion>2.12</scala.baseVersion>
-    <scala.version>2.12.6</scala.version>
+    <scala.version>2.12.8</scala.version>
   </properties>
 
   <dependencies>

--- a/flo-scala_2.12/pom.xml
+++ b/flo-scala_2.12/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.baseVersion}</artifactId>
-      <version>3.0.5</version>
+      <version>3.0.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,11 @@
         <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
         <version>2.11.0</version>
       </dependency>
+      <dependency><!-- to please enforcer-->
+        <groupId>com.google.apis</groupId>
+        <artifactId>google-api-services-storage</artifactId>
+        <version>v1-rev20181109-1.27.0</version>
+      </dependency>
 
       <!-- version resolution -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </modules>
 
   <properties>
-    <grpc.version>1.13.1</grpc.version>
+    <grpc.version>1.17.1</grpc.version>
     <jackson.version>2.9.10</jackson.version>
     <jackson.databind.version>${jackson.version}.1</jackson.databind.version>
     <google.client.version>1.27.0</google.client.version>
@@ -111,7 +111,7 @@
       <dependency>
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
-        <version>1.0-rc3</version>
+        <version>1.0-rc5</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -132,7 +132,7 @@
       <dependency>
         <groupId>io.norberg</groupId>
         <artifactId>auto-matter</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -206,12 +206,12 @@
       <dependency>
         <groupId>org.apache.beam</groupId>
         <artifactId>beam-runners-direct-java</artifactId>
-        <version>2.6.0</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.beam</groupId>
         <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-        <version>2.6.0</version>
+        <version>2.11.0</version>
       </dependency>
 
       <!-- version resolution -->
@@ -343,7 +343,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.6.Final</version>
+        <version>2.0.25.Final</version>
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
@@ -383,7 +383,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.25.Final</version>
+        <version>4.1.38.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,8 @@
     <jackson.version>2.9.10</jackson.version>
     <jackson.databind.version>${jackson.version}.1</jackson.databind.version>
     <google.client.version>1.27.0</google.client.version>
-    <google.auth.version>0.9.1</google.auth.version>
+    <google.auth.version>0.12.0</google.auth.version>
+    <protobuf-java.version>3.7.0</protobuf-java.version>
   </properties>
 
   <dependencyManagement>
@@ -248,12 +249,12 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.6.0</version>
+        <version>${protobuf-java.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java-util</artifactId>
-        <version>3.6.0</version>
+        <version>${protobuf-java.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
@@ -293,7 +294,7 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>api-common</artifactId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
       </dependency>
       <dependency>
         <groupId>io.grpc</groupId>
@@ -323,7 +324,7 @@
       <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-api</artifactId>
-        <version>0.12.3</version>
+        <version>0.17.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
@@ -348,17 +349,17 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-spanner-admin-database-v1</artifactId>
-        <version>0.1.11</version>
+        <version>1.6.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax</artifactId>
-        <version>1.29.0</version>
+        <version>1.38.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-core</artifactId>
-        <version>1.36.0</version>
+        <version>1.61.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Bump libraries to the ones used by Scio 0.7.4 

## Motivation and Context
Internally at Spotify we package Flo with related technologies like Scio, so it is better to use the same library versions to reduce the possibility of version conflicts

## Have you tested this? If so, how?
I am relying on existing test suite to catch errors

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
