### PR TITLE
Be able to pass success to BigQueryOperation

### DIFF
--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryOperation.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryOperation.java
@@ -61,6 +61,10 @@ public class BigQueryOperation<T> implements Serializable {
     return new BigQueryOperation<T>().job(job);
   }
 
+  static <T> BigQueryOperation<T> ofJob(Fn<JobInfo> job, F1<JobInfo, T> success) {
+    return new BigQueryOperation<T>().job(job).success(success);
+  }
+
   public static class Provider<T> implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -94,6 +98,10 @@ public class BigQueryOperation<T> implements Serializable {
 
     public BigQueryOperation<T> job(JobInfo jobInfo) {
       return BigQueryOperation.ofJob(() -> jobInfo);
+    }
+
+    public BigQueryOperation<T> job(JobInfo jobInfo, F1<JobInfo, T> success) {
+      return BigQueryOperation.ofJob(() -> jobInfo, success);
     }
   }
 }

--- a/contrib/flo-bigquery/src/test/java/com/spotify/flo/contrib/bigquery/BigQueryOperatorTest.java
+++ b/contrib/flo-bigquery/src/test/java/com/spotify/flo/contrib/bigquery/BigQueryOperatorTest.java
@@ -121,6 +121,26 @@ public class BigQueryOperatorTest {
   }
 
   @Test
+  public void shouldRunLoadJobInTestModeWithSuccess() throws Exception {
+    final TableId dstTable = TableId.of("foo", "bar", "baz");
+    final String srcUri = "gs://foo/bar";
+
+    final Task<TableId> task = Task.named("task")
+        .ofType(TableId.class)
+        .operator(BigQueryOperator.create())
+        .process(bq -> bq.job(
+            JobInfo.of(LoadJobConfiguration.of(dstTable, srcUri)), response -> dstTable));
+
+    try (TestScope scope = FloTesting.scope()) {
+
+      final TableId result = FloRunner.runTask(task).future()
+          .get(30, SECONDS);
+
+      assertThat(result, is(dstTable));
+    }
+  }
+
+  @Test
   public void shouldRunExtractJobInTestMode() throws Exception {
     final TableId srcTable = TableId.of("foo", "bar", "baz");
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

Add a public method to pass a success function to a BigQueryOperation.
Solves #208.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [x] Changes are covered by unit test
- [x] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
