### PR TITLE
Make success hook public

### DIFF
--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryOperation.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/BigQueryOperation.java
@@ -52,7 +52,7 @@ public class BigQueryOperation<T> implements Serializable {
   /**
    * Specify some action to take on success. E.g. publishing a staging table.
    */
-  BigQueryOperation<T> success(F1<JobInfo, T> success) {
+  public BigQueryOperation<T> success(F1<JobInfo, T> success) {
     this.success = Objects.requireNonNull(success);
     return this;
   }


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Make `BigQueryOperation.success` public
## Motivation and Context
As described in https://github.com/spotify/flo/pull/125 , the original
idea was to be able to write
```java
final Task<TableId> task = Task.named("task")
    .ofType(TableId.class)
    .context(BigQueryContext.create(table))
    .context(BigQueryOperator.create())
    .process((stagingTable, bq) -> bq.job(
        JobInfo.of(QueryJobConfiguration.newBuilder("SELECT foo FROM input")
            .setDestinationTable(stagingTable.tableId())
            .build()))
        .success(response -> stagingTable.publish()));
```
But because success is package private this use case is only allowed in
the classes in the same package, like in the unit test

## Have you tested this? If so, how?
Same test suit. Manually I also created a dummy class with main and copied the code above

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [x ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
