### PR TITLE
Reload BigQuery job after it is done in order to correctly capture errors

### DIFF
--- a/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/DefaultBigQueryClient.java
+++ b/contrib/flo-bigquery/src/main/java/com/spotify/flo/contrib/bigquery/DefaultBigQueryClient.java
@@ -78,6 +78,7 @@ class DefaultBigQueryClient implements FloBigQueryClient {
       }
       job = job.reload();
     }
+    job = job.reload();
 
     final BigQueryError error = job.getStatus().getError();
     if (error != null) {


### PR DESCRIPTION
In the case where a BigQuery job fails immediately (e.g. bucket does not exist in GCS) the job is never reloaded, and errors are lost.
In this case the job is treated as DONE, whilst the returned JobInfo may still report that the job is RUNNING.
By reloading the job after it is DONE, errors are captured and the true state of the job is returned from the library.

# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or -->
<!--- "I ran my jobs with this code and it works for me." -->

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
