### PR TITLE
Use authenticated docker hub pull

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
     working_directory: ~/flo
     docker:
       - image: maven:3.5.4-jdk-8
+        auth:
+          username: spotifyci
+          password: $DOCKERHUB_TOKEN
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Use authenticated docker hub pull

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dockerhub will rate limit unauthenticated pull and that may impact our Circle CI build.

https://circleci.com/docs/2.0/private-images/

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or -->
<!--- "I ran my jobs with this code and it works for me." -->
As long as PR build passes, this works.

## Checklist for PR author(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Changes are covered by unit test
- [ ] All tests pass
- [ ] Code coverage check passes
- [ ] Error handling is tested
- [ ] Errors are handled at the appropriate layer
- [ ] Errors that cannot be handled where they occur are propagated
- [ ] Relevant documentation updated
- [ ] This PR has NO breaking change to public API
- [ ] This PR has breaking change to public API and it is documented

## Checklist for PR reviewer(s)
<!--- Put an `x` in all the boxes that apply: -->
- [ ] This PR has been incorporated in release note for the coming version
- [ ] Risky changes introduced by this PR have been all considered

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
